### PR TITLE
jest config에 src/.. 절대 경로를 위한 설정 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,9 @@
     "collectCoverageFrom": [
       "**/*.(t|j)s"
     ],
-    "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "src/(.*)": "<rootDir>/$1"
+    }
   }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 버그 수정  

### 이슈번호
#2

### 반영 브랜치
feature/fix-jest-absolute-path -> dev

### 변경 사항
- package.json에 있는 jest의 설정에 moduleNameMapper로 src 절대경로도 test를 돌렸을 때 정상작동하게 함.

### 테스트 결과
절대 경로 문제는 해결되었으나 의존성 문제로 테스트는 실패함.
버그로 제기된 src 절대 경로의 오류는 해결됨.