### PR TITLE
인증: API와 User Entity의 이슈 해결

### DIFF
--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -86,6 +86,7 @@ describe('AuthService', () => {
         if (token === getRepositoryToken(User)) {
           return {
             insert: jest.fn(),
+            findOne: jest.fn(),
             findOneBy: jest.fn(),
             update: jest.fn(),
           };
@@ -169,7 +170,7 @@ describe('AuthService', () => {
       const response: any = {
         cookie: jest.fn(() => response),
       };
-      mockUserRepository.findOneBy.mockResolvedValue(users[0]);
+      mockUserRepository.findOne.mockResolvedValue(users[0]);
       mockJwtService.sign.mockImplementation((payload: any, options: any) => {
         return `token${options.secret}`;
       });

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -64,7 +64,7 @@ export class AuthService {
   async signIn(body: SignInBodyDTO, response: any) {
     try {
       const { email, password } = body;
-      const user = await this.usersRepository.findOneBy({ email });
+      const user = await this.usersRepository.findOne({ where: { email }, select: { id: true, email: true, password: true } });
       if (!user) {
         throw new NotFoundException({ message: '가입하지 않은 이메일입니다.' });
       }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -62,7 +62,6 @@ export class AuthService {
   }
 
   async signIn(body: SignInBodyDTO, response: any) {
-    try {
       const { email, password } = body;
       const user = await this.usersRepository.findOne({ where: { email }, select: { id: true, email: true, password: true } });
       if (!user) {
@@ -100,12 +99,6 @@ export class AuthService {
         accessToken,
         refreshToken,
       };
-    } catch (e) {
-      console.error(e);
-      throw new InternalServerErrorException({
-        message: '로그인이 제대로 이뤄지지 않았습니다.',
-      });
-    }
   }
 
   async signOut(user: any, response: any) {

--- a/src/auth/dto/auth.dto.ts
+++ b/src/auth/dto/auth.dto.ts
@@ -26,6 +26,7 @@ export class SignUpBodyDTO {
 }
 
 export class VerifyTokenDTO {
+  @Type(() => Number)
   @IsInt({
     message: '이메일 인증토큰은 정수여야합니다.',
   })

--- a/src/auth/dto/auth.dto.ts
+++ b/src/auth/dto/auth.dto.ts
@@ -1,23 +1,34 @@
 import { IntersectionType, PickType } from '@nestjs/mapped-types';
 import { Type } from 'class-transformer';
-import { IsEmail, IsNotEmpty, IsStrongPassword } from 'class-validator';
+import { IsEmail, IsInt, IsNotEmpty, IsNumber, IsStrongPassword } from 'class-validator';
 
 export class SignUpBodyDTO {
-  @IsEmail()
+  @IsEmail(
+    {},
+    {
+      message: 'email은 이메일의 형식이어야 합니다.',
+    }
+  )
   email: string;
-  @IsStrongPassword({
-    minLength: 8,
-    minLowercase: 0,
-    minNumbers: 0,
-    minSymbols: 0,
-    minUppercase: 0,
-  })
+  @IsStrongPassword(
+    {
+      minLength: 8,
+      minLowercase: 0,
+      minNumbers: 0,
+      minSymbols: 0,
+      minUppercase: 0,
+    },
+    {
+      message: '비밀번호는 최소 8자리의 문자열이어야합니다.',
+    }
+  )
   password: string;
 }
 
 export class VerifyTokenDTO {
-  @IsNotEmpty()
-  @Type(() => Number)
+  @IsInt({
+    message: '이메일 인증토큰은 정수여야합니다.',
+  })
   verifyToken: number;
 }
 

--- a/src/auth/entities/user.entity.ts
+++ b/src/auth/entities/user.entity.ts
@@ -12,7 +12,7 @@ export class User {
   @Column('varchar', { unique: true })
   email: string;
 
-  @Column('varchar')
+  @Column('varchar', { select: false })
   password: string;
 
   @Column('bool', { default: false })


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택)
- [ ] 기능 추가   
- [x] 기능 수정   
- [ ] 기능 삭제   
- [x] 버그 수정   
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- resolve #46

- AuthService의 try-catch 문 제거
- Auth API에 쓰이는 DTO들의 유효성 검사 실패 시 노출되는 메시지 설정. + 유효성 검사 조건 미세조정
- User 엔티티가 조인될 때 패스워드가 노출되지 않도록 조회 시에 패스워드의 select를 false로 바꿈. 그에 영향을 받아서 제 기능이 안 되는 코드 수정.

### 테스트 결과
정상