### PR TITLE
feat: 로그인, 로그아웃의 스테이터스 코드 변경 + 유저 엔티티에 username, provider 추가

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Patch, Post, Put, Res, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, Patch, Post, Put, Res, UseGuards } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import {
   PostEmailVerificationBodyDTO,
@@ -26,12 +26,14 @@ export class AuthController {
   }
 
   @Post('signin')
+  @HttpCode(200)
   async signIn(@Body() body: SignInBodyDTO, @Res({ passthrough: true }) response: any) {
     return await this.authService.signIn(body, response);
   }
 
   @Post('signout')
   @UseGuards(JwtGuard)
+  @HttpCode(200)
   async signOut(@InjectUser() user: any, @Res({ passthrough: true }) response: any) {
     return await this.authService.signOut(user, response);
   }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -2,14 +2,14 @@ import { CacheModule, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
-import { User } from './entities/user.entity';
+import { LocalUser, User, NaverUser, KaKaoUser } from './entities/user.entity';
 import { JwtModule } from '@nestjs/jwt';
 import { MailerProviderModule } from 'src/mailer/mailer.module';
 import { JwtRefreshStrategy } from './guard/jwt-refresh/jwt-refresh.strategy';
 import { JwtStrategy } from './guard/jwt/jwt.strategy';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User]), JwtModule, CacheModule.register(), MailerProviderModule],
+  imports: [TypeOrmModule.forFeature([User, LocalUser, NaverUser, KaKaoUser]), JwtModule, CacheModule.register(), MailerProviderModule],
   controllers: [AuthController],
   providers: [AuthService, JwtStrategy, JwtRefreshStrategy],
 })

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -135,6 +135,7 @@ describe('AuthService', () => {
 
     it('should be return success message when success situation', async () => {
       const body: SignUpBodyDTO = {
+        username: '테스트맨',
         email: 'testman@gmail.com',
         password: 'testpassword',
       };
@@ -144,7 +145,7 @@ describe('AuthService', () => {
       expect(service.signUp(body)).resolves.toStrictEqual({
         message: '회원가입 되었습니다.',
       });
-      expect(mockLocalUserRepository.insert).toHaveBeenCalledWith({ email: body.email, password: bcrypt.hashSync(body.password, 10) });
+      expect(mockLocalUserRepository.insert).toHaveBeenCalledWith({ username: body.username, email: body.email, password: bcrypt.hashSync(body.password, 10) });
     });
 
     it('should be return fail message when error situation', async () => {

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -133,7 +133,7 @@ describe('AuthService', () => {
       expect(typeof service.signUp).toBe('function');
     });
 
-    it('should be return success message when success situation', async () => {
+    it.only('should be return success message when success situation', async () => {
       const body: SignUpBodyDTO = {
         username: '테스트맨',
         email: 'testman@gmail.com',
@@ -145,7 +145,22 @@ describe('AuthService', () => {
       expect(service.signUp(body)).resolves.toStrictEqual({
         message: '회원가입 되었습니다.',
       });
-      expect(mockLocalUserRepository.insert).toHaveBeenCalledWith({ username: body.username, email: body.email, password: bcrypt.hashSync(body.password, 10) });
+    });
+
+    it('should be return fail message when username error situation', async () => {
+      const body: SignUpBodyDTO = {
+        username: '중복닉네임',
+        email: 'test@gmail.com',
+        password: 'testpassword',
+      };
+
+      mockLocalUserRepository.findOne.mockResolvedValueOnce(users[0])
+
+      expect(service.signUp(body)).rejects.toThrowError(
+        new BadRequestException({
+          message: '해당 닉네임으로 이미 가입한 유저가 존재합니다.',
+        })
+      );
     });
 
     it('should be return fail message when error situation', async () => {

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -133,7 +133,7 @@ describe('AuthService', () => {
       expect(typeof service.signUp).toBe('function');
     });
 
-    it.only('should be return success message when success situation', async () => {
+    it('should be return success message when success situation', async () => {
       const body: SignUpBodyDTO = {
         username: '테스트맨',
         email: 'testman@gmail.com',

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -2,7 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { AuthService } from './auth.service';
 import { ModuleMocker, MockFunctionMetadata } from 'jest-mock';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { User } from './entities/user.entity';
+import { LocalUser } from './entities/user.entity';
 import { FindOptionsWhere, Repository } from 'typeorm';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
@@ -22,7 +22,7 @@ const moduleMocker = new ModuleMocker(global);
 
 describe('AuthService', () => {
   let service: AuthService;
-  let mockUserRepository: jest.Mocked<Repository<User>>;
+  let mockLocalUserRepository: jest.Mocked<Repository<LocalUser>>;
   let mockJwtService: jest.Mocked<JwtService>;
   let mockConfigService: jest.Mocked<ConfigService>;
   let mockMailerAuthService: jest.Mocked<MailerAuthService>;
@@ -89,7 +89,7 @@ describe('AuthService', () => {
       providers: [AuthService],
     })
       .useMocker((token) => {
-        if (token === getRepositoryToken(User)) {
+        if (token === getRepositoryToken(LocalUser)) {
           return {
             insert: jest.fn(),
             findOne: jest.fn(),
@@ -115,7 +115,7 @@ describe('AuthService', () => {
       .compile();
 
     service = module.get(AuthService);
-    mockUserRepository = module.get(getRepositoryToken(User));
+    mockLocalUserRepository = module.get(getRepositoryToken(LocalUser));
     mockJwtService = module.get(JwtService);
     mockConfigService = module.get(ConfigService);
     mockMailerAuthService = module.get(MailerAuthService);
@@ -139,12 +139,12 @@ describe('AuthService', () => {
         password: 'testpassword',
       };
 
-      mockUserRepository.insert.mockResolvedValue({ generatedMaps: [], identifiers: [], raw: false });
+      mockLocalUserRepository.insert.mockResolvedValue({ generatedMaps: [], identifiers: [], raw: false });
 
       expect(service.signUp(body)).resolves.toStrictEqual({
         message: '회원가입 되었습니다.',
       });
-      expect(mockUserRepository.insert).toHaveBeenCalledWith({ email: body.email, password: bcrypt.hashSync(body.password, 10) });
+      expect(mockLocalUserRepository.insert).toHaveBeenCalledWith({ email: body.email, password: bcrypt.hashSync(body.password, 10) });
     });
 
     it('should be return fail message when error situation', async () => {
@@ -152,7 +152,7 @@ describe('AuthService', () => {
         email: 'test@gmail.com',
         password: 'testpassword',
       };
-      mockUserRepository.insert.mockRejectedValue(new Error());
+      mockLocalUserRepository.insert.mockRejectedValue(new Error());
 
       expect(service.signUp(body)).rejects.toThrowError(
         new BadRequestException({
@@ -176,7 +176,7 @@ describe('AuthService', () => {
       const response: any = {
         cookie: jest.fn(() => response),
       };
-      mockUserRepository.findOne.mockResolvedValue(users[0]);
+      mockLocalUserRepository.findOne.mockResolvedValue(users[0]);
       mockJwtService.sign.mockImplementation((payload: any, options: any) => {
         return `token${options.secret}`;
       });
@@ -287,10 +287,10 @@ describe('AuthService', () => {
       cache = {
         refreshToken: 1,
       };
-      mockUserRepository.findOne.mockResolvedValue({
+      mockLocalUserRepository.findOne.mockResolvedValue({
         id: 1,
         email: 'test@gmail.com',
-      } as User);
+      } as LocalUser);
       mockJwtService.sign.mockReturnValueOnce(newAccessToken);
       mockJwtService.verifyAsync.mockResolvedValue({})
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -39,6 +39,7 @@ export class AuthService {
     for (let i = 1; i <= 5; i++) {
       const temp = {
         email: `test_emai_${i}@gmail.com`,
+        username: `test${i}`,
         password: bcrypt.hashSync('qwer1234', 10),
       };
       arr.push(temp);
@@ -51,9 +52,10 @@ export class AuthService {
   }
 
   async signUp(body: SignUpBodyDTO) {
-    const { email, password } = body;
+    const { username: _username, email, password } = body;
+    const username = _username || `${email.split('@')[0]}#${Math.floor(Math.random() * 10000) + 1}`
     const passwordHash = bcrypt.hashSync(password, 10);
-    await this.usersRepository.insert({ email, password: passwordHash }).catch((err) => {
+    await this.usersRepository.insert({ username, email, password: passwordHash }).catch((err) => {
       throw new BadRequestException({
         message: '회원가입에 적절하지 않은 이메일과 패스워드입니다.',
       });

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -53,7 +53,13 @@ export class AuthService {
 
   async signUp(body: SignUpBodyDTO) {
     const { username: _username, email, password } = body;
-    const username = _username || `${email.split('@')[0]}#${Math.floor(Math.random() * 10000) + 1}`
+    const user = !_.isNil(_username) ? await this.localUsersRepository.findOne({ where: { username: _username } }) : null;
+    if (!_.isNil(user)) {
+      throw new BadRequestException({
+        message: '해당 닉네임으로 이미 가입한 유저가 존재합니다.',
+      });
+    }
+    const username = _username || `${email.split('@')[0]}#${Math.floor(Math.random() * 10000) + 1}`;
     const passwordHash = bcrypt.hashSync(password, 10);
     await this.localUsersRepository.insert({ username, email, password: passwordHash }).catch((err) => {
       throw new BadRequestException({
@@ -164,7 +170,7 @@ export class AuthService {
       });
     }
 
-    const newAccessToken = this.generateUserAccessToken(user)
+    const newAccessToken = this.generateUserAccessToken(user);
 
     return {
       accessToken: newAccessToken,

--- a/src/auth/dto/auth.dto.ts
+++ b/src/auth/dto/auth.dto.ts
@@ -1,8 +1,16 @@
 import { IntersectionType, PickType } from '@nestjs/mapped-types';
 import { Type } from 'class-transformer';
-import { IsEmail, IsInt, IsNumber, IsString, IsStrongPassword } from 'class-validator';
+import { IsEmail, IsInt, IsNotEmpty, IsOptional, IsNumber, IsString, IsStrongPassword } from 'class-validator';
 
 export class SignUpBodyDTO {
+  @IsOptional()
+  @IsNotEmpty({
+    message: '유저명은 빈문자열이면 안 됩니다.'
+  })
+  @IsString({
+    message: '유저명은 문자열이어야 합니다.'
+  })
+  username: string;
   @IsEmail(
     {},
     {

--- a/src/auth/dto/auth.dto.ts
+++ b/src/auth/dto/auth.dto.ts
@@ -10,7 +10,7 @@ export class SignUpBodyDTO {
   @IsString({
     message: '유저명은 문자열이어야 합니다.'
   })
-  username: string;
+  username?: string;
   @IsEmail(
     {},
     {

--- a/src/auth/entities/user.entity.ts
+++ b/src/auth/entities/user.entity.ts
@@ -15,7 +15,7 @@ export class User {
   @Column('varchar', { select: false })
   password: string;
 
-  @Column('varchar', { unique: true })
+  @Column('varchar')
   username: string;
 
   @Column('varchar', { nullable: true})

--- a/src/auth/entities/user.entity.ts
+++ b/src/auth/entities/user.entity.ts
@@ -15,6 +15,12 @@ export class User {
   @Column('varchar', { select: false })
   password: string;
 
+  @Column('varchar', { unique: true })
+  username: string;
+
+  @Column('varchar')
+  provider: string | null;
+
   @Column('bool', { default: false })
   isBlock: boolean;
 

--- a/src/auth/entities/user.entity.ts
+++ b/src/auth/entities/user.entity.ts
@@ -2,9 +2,20 @@ import { Collection } from 'src/collections/entities/collection.entity';
 import { Photospot } from 'src/photospot/entities/photospot.entity';
 import { Join } from 'src/meetups/entities/join.entity';
 import { Meetup } from 'src/meetups/entities/meetup.entity';
-import { Column, CreateDateColumn, DeleteDateColumn, Entity, OneToMany, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+import {
+  ChildEntity,
+  Column,
+  CreateDateColumn,
+  DeleteDateColumn,
+  Entity,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  TableInheritance,
+  UpdateDateColumn,
+} from 'typeorm';
 
 @Entity({ schema: 'chalkak', name: 'user' })
+@TableInheritance({ column: { type: 'varchar', name: 'provider' } })
 export class User {
   @PrimaryGeneratedColumn({ type: 'int', name: 'id' })
   id: number;
@@ -12,14 +23,8 @@ export class User {
   @Column('varchar', { unique: true })
   email: string;
 
-  @Column('varchar', { select: false })
-  password: string;
-
-  @Column('varchar')
+  @Column('varchar', { unique: true })
   username: string;
-
-  @Column('varchar', { nullable: true})
-  provider: string | null;
 
   @Column('bool', { default: false })
   isBlock: boolean;
@@ -45,3 +50,15 @@ export class User {
   @OneToMany((type) => Join, (join) => join.user)
   joins: Join[];
 }
+
+@ChildEntity('local')
+export class LocalUser extends User {
+  @Column('varchar', { select: false })
+  password: string;
+}
+
+@ChildEntity('naver')
+export class NaverUser extends User {}
+
+@ChildEntity('kakao')
+export class KaKaoUser extends User {}

--- a/src/auth/entities/user.entity.ts
+++ b/src/auth/entities/user.entity.ts
@@ -18,7 +18,7 @@ export class User {
   @Column('varchar', { unique: true })
   username: string;
 
-  @Column('varchar')
+  @Column('varchar', { nullable: true})
   provider: string | null;
 
   @Column('bool', { default: false })

--- a/src/common/config/typeorm.config.service.ts
+++ b/src/common/config/typeorm.config.service.ts
@@ -3,11 +3,12 @@ import { ConfigService } from '@nestjs/config';
 import { TypeOrmModuleOptions, TypeOrmOptionsFactory } from '@nestjs/typeorm';
 import { Admin } from 'src/admin/entities/admin.entity';
 import { Faq } from 'src/admin/entities/faq.entity';
-import { User } from 'src/auth/entities/user.entity';
+import { KaKaoUser, NaverUser, User } from 'src/auth/entities/user.entity';
 import { Collection } from 'src/collections/entities/collection.entity';
 import { Photospot } from 'src/photospot/entities/photospot.entity';
 import { Join } from 'src/meetups/entities/join.entity';
 import { Meetup } from 'src/meetups/entities/meetup.entity';
+import { LocalUser } from '../../auth/entities/user.entity';
 
 @Injectable()
 export class TypeOrmConfigService implements TypeOrmOptionsFactory {
@@ -22,7 +23,7 @@ export class TypeOrmConfigService implements TypeOrmOptionsFactory {
       password: this.configService.get<string>('DATABASE_PASSWORD'),
       database: this.configService.get<string>('DATABASE_NAME'),
       synchronize: Boolean(this.configService.get<string>('DATABASE_SYNC')),  // 배포 시 false
-      entities: [User, Collection, Photospot, Meetup, Join, Admin, Faq],
+      entities: [User, LocalUser, NaverUser, KaKaoUser, Collection, Photospot, Meetup, Join, Admin, Faq],
     };
   }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택)
- [x] 기능 추가   
- [x] 기능 수정   
- [ ] 기능 삭제   
- [ ] 버그 수정   
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- resolve #63 
    - 로그인, 로그아웃 스테이터스 코드 200 수정
- resolve #67 
    - username 컬럼 추가 - 회원의 유저명
    - provider 컬럼 추가 - 'local'(이메일 패스워드 로그인), 'naver', 'kakao' (소셜 로그인 시)
    - 회원가입 시에 username을 선택적으로 받으며 받지 않았을 경우에는 계정명 + #(랜덤숫자)로 겹치지 않게 생성하여 넣어줌.
    - 소셜 로그인 시에 패스워드가 존재하지 않기 때문에 기존의 User 엔터티를 사용할 수 없음. 그래서 각 로그인방식에 따라 엔티티를 상속하여 나눔.
    - 기존의 usersRepository를 사용하려하는 경우에는 `@InjectRepository(LocalUser)` 사용하도록 변경
    - username 추가에 따른 테스트코드 변경

### 테스트 결과
정상

### 문의사항
새로 늘어나는 provider 필드가 null을 허용하지 않기 때문에 user 테이블에 데이터가 이미 존재하는 경우 에러가 나며, username의 경우에도 unique를 걸어놔 같은 값이 들어가면 에러가 남. 데이터를 지우지 않고도 가능한 방법이 있으면 알려주시면 감사하겠습니다.