### PR TITLE
feat: 블락된 유저의 권한 제한

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { CacheModule, Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AppController } from './app.controller';
@@ -21,6 +21,7 @@ import { PhotospotModule } from './photospot/photospot.module';
         expiresIn: '1h',
       },
     }),
+    CacheModule.register({ isGlobal: true }),
     AuthModule,
     CollectionsModule,
     MeetupsModule,

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -8,8 +8,7 @@ import {
   ChangePasswordBodyDTO,
   ProviderDTO,
 } from './dto/auth.dto';
-import { InjectUser, Token } from './auth.decorator';
-import { JwtGuard } from './guard/jwt/jwt.guard';
+import { InjectUser, Token, UserGuard } from './auth.decorator';
 import { JwtRefreshGuard } from './guard/jwt-refresh/jwt-refresh.guard';
 import { SocialLoginBodyDTO } from './dto/auth.dto';
 
@@ -34,7 +33,7 @@ export class AuthController {
   }
 
   @Post('signout')
-  @UseGuards(JwtGuard)
+  @UseGuards(UserGuard)
   @HttpCode(200)
   async signOut(@InjectUser() user: any, @Res({ passthrough: true }) response: any) {
     return await this.authService.signOut(user, response);
@@ -51,7 +50,7 @@ export class AuthController {
   }
 
   @Patch('')
-  @UseGuards(JwtGuard)
+  @UseGuards(UserGuard)
   async changePassword(@Body() body: ChangePasswordBodyDTO, @InjectUser() user: any) {
     return await this.authService.changePassword(body, user);
   }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -33,7 +33,7 @@ export class AuthController {
   }
 
   @Post('signout')
-  @UseGuards(UserGuard)
+  @UserGuard
   @HttpCode(200)
   async signOut(@InjectUser() user: any, @Res({ passthrough: true }) response: any) {
     return await this.authService.signOut(user, response);
@@ -50,7 +50,7 @@ export class AuthController {
   }
 
   @Patch('')
-  @UseGuards(UserGuard)
+  @UserGuard
   async changePassword(@Body() body: ChangePasswordBodyDTO, @InjectUser() user: any) {
     return await this.authService.changePassword(body, user);
   }

--- a/src/auth/auth.decorator.ts
+++ b/src/auth/auth.decorator.ts
@@ -1,4 +1,8 @@
-import { createParamDecorator, ExecutionContext } from "@nestjs/common";
+import { createParamDecorator, ExecutionContext, UseGuards } from '@nestjs/common';
+import { JwtGuard } from './guard/jwt/jwt.guard';
+import { BlockUserGuard } from './guard/block-user/block-user.guard';
+
+export const UserGuard = UseGuards(JwtGuard, BlockUserGuard);
 
 export const InjectUser = createParamDecorator((data: string, ctx: ExecutionContext) => {
   const { user } = ctx.switchToHttp().getRequest();

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,4 +1,4 @@
-import { CacheModule, Module } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
@@ -10,7 +10,7 @@ import { JwtStrategy } from './guard/jwt/jwt.strategy';
 import { SocialModule } from 'src/social/social.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, LocalUser, NaverUser, KakaoUser]), JwtModule, CacheModule.register(), MailerProviderModule, SocialModule],
+  imports: [TypeOrmModule.forFeature([User, LocalUser, NaverUser, KakaoUser]), JwtModule, MailerProviderModule, SocialModule],
   controllers: [AuthController],
   providers: [AuthService, JwtStrategy, JwtRefreshStrategy],
 })

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -26,6 +26,7 @@ import { Cache } from 'cache-manager';
 import _ from 'lodash';
 import { SocialNaverService } from '../social/service/social.naver.service';
 import { SocialKakaoService } from 'src/social/service/social.kakao.service';
+import { ForbiddenException } from '@nestjs/common';
 
 @Injectable()
 export class AuthService {
@@ -84,6 +85,11 @@ export class AuthService {
     const user = await this.localUsersRepository.findOne({ where: { email }, select: ['id', 'email', 'username', 'password']});
     if (!user) {
       throw new NotFoundException({ message: '가입하지 않은 이메일입니다.' });
+    }
+    if (user.isBlock) {
+      throw new ForbiddenException({
+        message: '블락된 상태여서 로그인할 수 없습니다.'
+      })
     }
     if (!bcrypt.compareSync(password, user.password)) {
       throw new UnauthorizedException({ message: '비밀번호가 일치하지 않습니다.' });
@@ -182,6 +188,11 @@ export class AuthService {
           providerUserId: id,
         },
       });
+    }
+    if (user!.isBlock) {
+      throw new ForbiddenException({
+        message: '블락된 상태여서 로그인할 수 없습니다.'
+      })
     }
 
     const accessToken = this.generateUserAccessToken({

--- a/src/auth/guard/block-user/block-user.guard.ts
+++ b/src/auth/guard/block-user/block-user.guard.ts
@@ -1,12 +1,12 @@
-import { CanActivate, ExecutionContext, Inject, Injectable, BadRequestException, UnauthorizedException, ForbiddenException } from '@nestjs/common';
+import { CanActivate, ExecutionContext, Inject, Injectable, UnauthorizedException, ForbiddenException, CACHE_MANAGER } from '@nestjs/common';
+import { Cache } from 'cache-manager';
 import _ from 'lodash';
-import { Observable } from 'rxjs';
 import { User } from 'src/auth/entities/user.entity';
 import { DataSource } from 'typeorm';
 
 @Injectable()
 export class BlockUserGuard implements CanActivate {
-  constructor(@Inject(DataSource) private readonly dataSource: DataSource) {}
+  constructor(@Inject(DataSource) private readonly dataSource: DataSource, @Inject(CACHE_MANAGER) private readonly cacheManager: Cache) {}
 
   async canActivate(ctx: ExecutionContext): Promise<boolean> {
     const {

--- a/src/auth/guard/block-user/block-user.guard.ts
+++ b/src/auth/guard/block-user/block-user.guard.ts
@@ -1,0 +1,22 @@
+import { CanActivate, ExecutionContext, Inject, Injectable } from '@nestjs/common';
+import _ from 'lodash';
+import { Observable } from 'rxjs';
+import { User } from 'src/auth/entities/user.entity';
+import { DataSource } from 'typeorm';
+
+@Injectable()
+export class BlockUserGuard implements CanActivate {
+  constructor(@Inject(DataSource) private readonly dataSource: DataSource) {}
+
+  canActivate(ctx: ExecutionContext): boolean | Promise<boolean> | Observable<boolean> {
+    const {
+      user: { id: userId },
+    } = ctx.switchToHttp().getRequest();
+    const usersRepository = this.dataSource.getRepository(User);
+
+    return usersRepository
+      .findOne({ where: { id: userId } })
+      .then((user) => !_.isNil(user))
+      .catch((err) => false);
+  }
+}

--- a/src/auth/guard/block-user/block-user.guard.ts
+++ b/src/auth/guard/block-user/block-user.guard.ts
@@ -13,12 +13,24 @@ export class BlockUserGuard implements CanActivate {
       user: { id: userId },
     } = ctx.switchToHttp().getRequest();
     const usersRepository = this.dataSource.getRepository(User);
+    const isBlock = await this.cacheManager.get<boolean>(`user-${userId}-block`);
+    if (!_.isNil(isBlock)) {
+      if (!isBlock) {
+        throw new ForbiddenException({
+          message: '블락된 상태여서 사용할 수 없습니다.'
+        })
+      }
+      return isBlock;
+    }
     const user = await usersRepository.findOne({ where: { id: userId } });
     if (_.isNil(user)) {
       throw new UnauthorizedException({
         message: '존재하지 않는 회원입니다.',
       });
     }
+    await this.cacheManager.set<boolean>(`user-${userId}-block`, user.isBlock, {
+      ttl: 1000 * 60 * 5
+    })
     if (user.isBlock) {
       throw new ForbiddenException({
         message: '블락된 상태여서 사용할 수 없습니다.'

--- a/src/meetups/meetups.controller.ts
+++ b/src/meetups/meetups.controller.ts
@@ -1,8 +1,7 @@
 import _ from 'lodash';
 import { Body, Controller, DefaultValuePipe, Delete, Get, Param, ParseIntPipe, Post, Query, UseGuards } from '@nestjs/common';
-import { InjectUser } from 'src/auth/auth.decorator';
+import { InjectUser, UserGuard } from 'src/auth/auth.decorator';
 import { decodedAccessTokenDTO } from 'src/auth/dto/auth.dto';
-import { JwtGuard } from 'src/auth/guard/jwt/jwt.guard';
 import { CreateMeetupDTO } from './dto/create-meetup.dto';
 import { Meetup } from './entities/meetup.entity';
 import { MeetupsService } from './meetups.service';
@@ -21,7 +20,7 @@ export class MeetupsController {
   }
 
   @Post()
-  @UseGuards(JwtGuard)
+  @UseGuards(UserGuard)
   async createMeetup(@Body() meetupDTO: CreateMeetupDTO, @InjectUser() userDTO: decodedAccessTokenDTO): Promise<void> {
     meetupDTO.userId = userDTO.id;
     return await this.meetupsService.createMeetup(meetupDTO);
@@ -33,19 +32,19 @@ export class MeetupsController {
   }
 
   @Delete(':meetupId')
-  @UseGuards(JwtGuard)
+  @UseGuards(UserGuard)
   async deleteMeetup(@Param('meetupId') meetupId: number, @InjectUser() userDTO: decodedAccessTokenDTO): Promise<void> {
     return await this.meetupsService.deleteMeetup(meetupId, userDTO.id);
   }
 
   @Post(':meetupId/join')
-  @UseGuards(JwtGuard)
+  @UseGuards(UserGuard)
   async addJoin(@Param('meetupId') meetupId: number, @InjectUser() userDTO: decodedAccessTokenDTO): Promise<void> {
     return await this.meetupsService.addJoin(meetupId, userDTO.id);
   }
 
   @Delete(':meetupId/join')
-  @UseGuards(JwtGuard)
+  @UseGuards(UserGuard)
   async deleteJoin(@Param('meetupId') meetupId: number, @InjectUser() userDTO: decodedAccessTokenDTO): Promise<void> {
     return await this.meetupsService.deleteJoin(meetupId, userDTO.id);
   }

--- a/src/meetups/meetups.controller.ts
+++ b/src/meetups/meetups.controller.ts
@@ -20,7 +20,7 @@ export class MeetupsController {
   }
 
   @Post()
-  @UseGuards(UserGuard)
+  @UserGuard
   async createMeetup(@Body() meetupDTO: CreateMeetupDTO, @InjectUser() userDTO: decodedAccessTokenDTO): Promise<void> {
     meetupDTO.userId = userDTO.id;
     return await this.meetupsService.createMeetup(meetupDTO);
@@ -32,19 +32,19 @@ export class MeetupsController {
   }
 
   @Delete(':meetupId')
-  @UseGuards(UserGuard)
+  @UserGuard
   async deleteMeetup(@Param('meetupId') meetupId: number, @InjectUser() userDTO: decodedAccessTokenDTO): Promise<void> {
     return await this.meetupsService.deleteMeetup(meetupId, userDTO.id);
   }
 
   @Post(':meetupId/join')
-  @UseGuards(UserGuard)
+  @UserGuard
   async addJoin(@Param('meetupId') meetupId: number, @InjectUser() userDTO: decodedAccessTokenDTO): Promise<void> {
     return await this.meetupsService.addJoin(meetupId, userDTO.id);
   }
 
   @Delete(':meetupId/join')
-  @UseGuards(UserGuard)
+  @UserGuard
   async deleteJoin(@Param('meetupId') meetupId: number, @InjectUser() userDTO: decodedAccessTokenDTO): Promise<void> {
     return await this.meetupsService.deleteJoin(meetupId, userDTO.id);
   }

--- a/src/meetups/meetups.repository.ts
+++ b/src/meetups/meetups.repository.ts
@@ -29,7 +29,7 @@ export class MeetupsRepository extends Repository<Meetup> {
       ])
       .leftJoin('m.joins', 'j')
       .leftJoin('m.user', 'u')
-      .where('m.title LIKE :keyword OR m.content LIKE :keyword', {
+      .where('u.isBlock = false AND (m.title LIKE :keyword OR m.content LIKE :keyword)', {
         keyword: `%${keyword}%`,
       })
       .orderBy('m.id', 'DESC')
@@ -78,7 +78,7 @@ export class MeetupsRepository extends Repository<Meetup> {
       .leftJoin('m.joins', 'j')
       .leftJoin('m.user', 'mu')
       .leftJoin('j.user', 'u')
-      .where('m.id = :id', { id: meetupId })
+      .where('u.isBlock = false AND m.id = :id', { id: meetupId })
       .getOne();
 
     if (_.isNil(meetup)) {

--- a/src/meetups/meetups.repository.ts
+++ b/src/meetups/meetups.repository.ts
@@ -29,7 +29,7 @@ export class MeetupsRepository extends Repository<Meetup> {
       ])
       .leftJoin('m.joins', 'j')
       .leftJoin('m.user', 'u')
-      .where('u.isBlock = false AND (m.title LIKE :keyword OR m.content LIKE :keyword)', {
+      .where('m.title LIKE :keyword OR m.content LIKE :keyword', {
         keyword: `%${keyword}%`,
       })
       .orderBy('m.id', 'DESC')
@@ -78,7 +78,7 @@ export class MeetupsRepository extends Repository<Meetup> {
       .leftJoin('m.joins', 'j')
       .leftJoin('m.user', 'mu')
       .leftJoin('j.user', 'u')
-      .where('u.isBlock = false AND m.id = :id', { id: meetupId })
+      .where('m.id = :id', { id: meetupId })
       .getOne();
 
     if (_.isNil(meetup)) {

--- a/src/photospot/photospot.controller.ts
+++ b/src/photospot/photospot.controller.ts
@@ -4,15 +4,14 @@ import { CreatePhotospotDto } from './dto/create-photospot.dto';
 import { ModifyPhotospotDto } from './dto/modify-photospot.dto';
 import { PhotospotService } from './photospot.service';
 import { Photospot } from './entities/photospot.entity';
-import { InjectUser } from '../auth/auth.decorator';
-import { JwtGuard } from '../auth/guard/jwt/jwt.guard';
+import { InjectUser, UserGuard } from '../auth/auth.decorator';
 
 @Controller('/api/collections')
 export class PhotospotController {
   constructor(private readonly photospotService: PhotospotService) {}
 
   @Post('/:collectionId/photospots')
-  @UseGuards(JwtGuard)
+  @UseGuards(UserGuard)
   @FormDataRequest()
   async createPhotospot(
     @Body() createPhtospotDto: CreatePhotospotDto,
@@ -33,7 +32,7 @@ export class PhotospotController {
   }
 
   @Put('/:collectionId/photospots/:photospotId')
-  @UseGuards(JwtGuard)
+  @UseGuards(UserGuard)
   @FormDataRequest()
   async modifyPhotospot(
     @Body() modifyPhotospot: ModifyPhotospotDto,
@@ -44,7 +43,7 @@ export class PhotospotController {
   }
 
   @Delete('/:collectionId/photospots/:photospotId')
-  @UseGuards(JwtGuard)
+  @UseGuards(UserGuard)
   async deletePhotospot(@Param('photospotId') photospotId: number, @InjectUser('id') userId: number) {
     await this.photospotService.deletePhotospot(photospotId, userId);
   }

--- a/src/photospot/photospot.controller.ts
+++ b/src/photospot/photospot.controller.ts
@@ -11,7 +11,7 @@ export class PhotospotController {
   constructor(private readonly photospotService: PhotospotService) {}
 
   @Post('/:collectionId/photospots')
-  @UseGuards(UserGuard)
+  @UserGuard
   @FormDataRequest()
   async createPhotospot(
     @Body() createPhtospotDto: CreatePhotospotDto,
@@ -32,7 +32,7 @@ export class PhotospotController {
   }
 
   @Put('/:collectionId/photospots/:photospotId')
-  @UseGuards(UserGuard)
+  @UserGuard
   @FormDataRequest()
   async modifyPhotospot(
     @Body() modifyPhotospot: ModifyPhotospotDto,
@@ -43,7 +43,7 @@ export class PhotospotController {
   }
 
   @Delete('/:collectionId/photospots/:photospotId')
-  @UseGuards(UserGuard)
+  @UserGuard
   async deletePhotospot(@Param('photospotId') photospotId: number, @InjectUser('id') userId: number) {
     await this.photospotService.deletePhotospot(photospotId, userId);
   }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택)
- [x] 기능 추가   
- [ ] 기능 수정   
- [ ] 기능 삭제   
- [ ] 버그 수정   
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 변경 사항
- 캐시매니저를 전역에서 사용할 수 있도록 CahceModule을 AuthModule에서 AppModule로 옮기고 isGlobal 옵션을 true로 함.
- resolve #64
    - 유저 데이터를 조회하여 isBlock이 true인지 판단하는 BlockUserGuard를 생성
    - 유저 데이터를 조회하는데 한 번 조회하고 나면 5분동안은 DB를 조회해서 확인하는 게 아니라, isBlock 여부를 캐시해서 DB 접근을 줄임 (추후 수정으로, 어드민에서 isBlock를 true로 만들 때 이 캐시에 true라고 저장해놓으면 5분 중간에 블락당해도 정상 작동함)
    - 유저 권한을 확인할 때, 액세스 토큰이 멀쩡한지 확인하고 블락당했는지를 확인해야하므로 그걸 하나로 묶어서 UserGuard를 만듬.
    - JwtGuard를 적용하던 곳을 UserGuard를 쓰도록 수정

### 테스트 결과
정상

### 추가사항
- 프론트엔드에서 apiAxios로 요청을 날릴 때, err 발생시 403이 떴다면 블락된 유저인 경우이므로 로그인을 취소해야함.
- 어드민에서 캐시매니저를 의존성 주입하고 isBlock을 true로 만들 때 캐시를 저장하려고 기능을 짜려했으나, 테스트코드의 변화도 줘야하고 사이드이펙트가 크므로 추후 수정 요구 예정
- 컬렉션 조회 기능은 dev에 안 합쳐져 있으므로 유저가 블락된 컬렉션을 조회 불가능하게 하는 건 아직 못 함.