### PR TITLE
feat: 인증 기능 약간 수정(리팩토링), 유저 유닛테스트 코드 커버리지 높임

### DIFF
--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -10,6 +10,7 @@ import { MailerAuthService } from 'src/mailer/service/mailer.auth.service';
 import {
   BadRequestException,
   CACHE_MANAGER,
+  ForbiddenException,
   InternalServerErrorException,
   NotFoundException,
   UnauthorizedException,
@@ -68,6 +69,7 @@ describe('AuthService', () => {
     users = [
       {
         id: 1,
+        username: 'test',
         email: 'test@gmail.com',
         password: 'testpassword|10',
         isBlock: false,
@@ -77,9 +79,20 @@ describe('AuthService', () => {
       },
       {
         id: 2,
+        username: 'test1',
         email: 'test@naver.com',
-        password: 'testpass|10',
+        password: 'testpassword|10',
         isBlock: false,
+        createdAt: new Date('2023-02-28T13:50:22.225Z'),
+        updatedAt: new Date('2023-02-28T13:50:32.144Z'),
+        deletedAt: new Date('2023-02-28T13:53:03.387Z'),
+      },
+      {
+        id: 3,
+        username: 'test3',
+        email: 'test3@naver.com',
+        password: 'testpassword|10',
+        isBlock: true,
         createdAt: new Date('2023-02-28T13:50:22.225Z'),
         updatedAt: new Date('2023-02-28T13:50:32.144Z'),
         deletedAt: new Date('2023-02-28T13:53:03.387Z'),
@@ -177,10 +190,10 @@ describe('AuthService', () => {
       };
 
       mockLocalUserRepository.insert.mockResolvedValue({
-        generatedMaps: [{ id: 3 }],
+        generatedMaps: [{ id: 4 }],
         identifiers: [
           {
-            id: 3,
+            id: 4,
             isBlock: false,
             createdAt: new Date('2023-03-06T15:01:25.962Z'),
             updatedAt: new Date('2023-03-06T15:01:25.962Z'),
@@ -190,7 +203,7 @@ describe('AuthService', () => {
         raw: {
           fieldCount: 0,
           affectedRows: 1,
-          insertId: 3,
+          insertId: 4,
           serverStatus: 2,
           warningCount: 0,
           message: '',
@@ -204,15 +217,15 @@ describe('AuthService', () => {
       });
     });
 
-    it('should be return fail message when username error situation', async () => {
-      const { username } = users[0]
+    it('should be return fail message when username error situation', () => {
+      const { username } = users[0];
       const body: SignUpBodyDTO = {
         username,
         email: 'test5@gmail.com',
         password: 'qwer1234',
       };
 
-      mockUserRepository.findOne.mockResolvedValueOnce(users[0]);
+      mockUserRepository.findOne.mockResolvedValue(users[0]);
 
       expect(service.signUp(body)).rejects.toThrowError(
         new BadRequestException({
@@ -262,6 +275,53 @@ describe('AuthService', () => {
         accessToken,
         refreshToken,
       });
+    });
+
+    it('should throw NotFoundException when email is not correct', async () => {
+      const body: SignInBodyDTO = {
+        email: 'fake' + users[0].email,
+        password: 'testpassword',
+      };
+      const response: any = {
+        cookie: jest.fn(() => response),
+      };
+      mockLocalUserRepository.findOne.mockResolvedValue(null);
+
+      expect(service.signIn(body, response)).rejects.toThrowError(
+        new NotFoundException({ message: '이메일이나 비밀번호가 일치하지 않습니다.' })
+      );
+    });
+
+    it('should throw NotFoundException when password is not correct', async () => {
+      const body: SignInBodyDTO = {
+        email: users[0].email,
+        password: 'faketestpassword',
+      };
+      const response: any = {
+        cookie: jest.fn(() => response),
+      };
+      mockLocalUserRepository.findOne.mockResolvedValue(users[0]);
+
+      expect(service.signIn(body, response)).rejects.toThrowError(
+        new NotFoundException({ message: '이메일이나 비밀번호가 일치하지 않습니다.' })
+      );
+    });
+
+    it('should throw ForbiddenException when user is block', async () => {
+      const body: SignInBodyDTO = {
+        email: users[2].email,
+        password: 'testpassword',
+      };
+      const response: any = {
+        cookie: jest.fn(() => response),
+      };
+      mockLocalUserRepository.findOne.mockResolvedValue(users[2]);
+
+      expect(service.signIn(body, response)).rejects.toThrowError(
+        new ForbiddenException({
+          message: '블락된 상태여서 로그인할 수 없습니다.',
+        })
+      );
     });
   });
 
@@ -316,12 +376,44 @@ describe('AuthService', () => {
       };
 
       cache = {
-        'test@gmail.com_verifyToken': 123456,
+        [`${body.email}_verifyToken`]: 123456,
       };
 
       expect(service.putEmailVerification(body)).resolves.toStrictEqual({
         message: '이메일 인증번호가 확인되었습니다.',
       });
+    });
+
+    it('should throw NotFoundException when verifyToken is not cached', async () => {
+      const body = {
+        email: 'test@gmail.com',
+        verifyToken: 123456,
+      };
+
+      cache = {};
+
+      expect(service.putEmailVerification(body)).rejects.toThrowError(
+        new NotFoundException({
+          message: '인증번호를 요청하지 않았거나 만료되었습니다.',
+        })
+      );
+    });
+
+    it('should throw UnauthorizedException when verifyToken is different with cachedVerifyToken', async () => {
+      const body = {
+        email: 'test@gmail.com',
+        verifyToken: 123456,
+      };
+
+      cache = {
+        [`${body.email}_verifyToken`]: 123458,
+      };
+
+      expect(service.putEmailVerification(body)).rejects.toThrowError(
+        new UnauthorizedException({
+          message: '인증번호가 일치하지 않습니다.',
+        })
+      );
     });
   });
 
@@ -362,11 +454,8 @@ describe('AuthService', () => {
       };
       const nickname = 'test-nickname';
       const providerUserId = 1;
-      mockUserRepository.findOne.mockResolvedValue(null);
-      mockNaverUserRepository.findOne.mockResolvedValue({
-        id: 1,
-        username: 'test',
-      } as NaverUser);
+      mockUserRepository.findOne.mockResolvedValueOnce(null);
+      mockNaverUserRepository.findOne.mockResolvedValue(users[0]);
       mockSocialNaverService.getOauth2Token.mockResolvedValue({ access_token: 'accessToken' });
       mockSocialNaverService.getUserInfo.mockResolvedValue({ id: providerUserId, nickname });
       mockJwtService.sign.mockImplementation((payload: any, options: any) => {
@@ -390,11 +479,8 @@ describe('AuthService', () => {
       };
       const nickname = 'test-nickname';
       const providerUserId = 1;
-      mockUserRepository.findOne.mockResolvedValue(null);
-      mockKakaoUserRepository.findOne.mockResolvedValue({
-        id: 1,
-        username: 'test',
-      } as KakaoUser);
+      mockUserRepository.findOne.mockResolvedValueOnce(null);
+      mockKakaoUserRepository.findOne.mockResolvedValue(users[0]);
       mockSocialKakaoService.getOauth2Token.mockResolvedValue({ access_token: 'accessToken' });
       mockSocialKakaoService.getUserInfo.mockResolvedValue({ id: providerUserId, kakao_account: { profile: { nickname } } });
       mockJwtService.sign.mockImplementation((payload: any, options: any) => {
@@ -408,6 +494,159 @@ describe('AuthService', () => {
         accessToken,
         refreshToken,
       });
+    });
+
+    it('should be return success message when username is exist', async () => {
+      const provider: 'kakao' | 'naver' = 'naver';
+      const body: SocialLoginBodyDTO = {
+        code: 'test',
+        state: 'chalkak',
+      };
+      const nickname = users[0].username;
+      const providerUserId = 1;
+      mockUserRepository.findOne.mockResolvedValueOnce(users[1]);
+      mockNaverUserRepository.findOne.mockResolvedValue(users[0]);
+      mockSocialNaverService.getOauth2Token.mockResolvedValue({ access_token: 'accessToken' });
+      mockSocialNaverService.getUserInfo.mockResolvedValue({ id: providerUserId, nickname });
+      mockJwtService.sign.mockImplementation((payload: any, options: any) => {
+        return `token${options.secret}`;
+      });
+      const accessToken = `token${mockConfigService.get('JWT_ACCESS_TOKEN_SECRET')}`;
+      const refreshToken = `token${mockConfigService.get('JWT_REFRESH_TOKEN_SECRET')}`;
+
+      expect(service.oauthSignIn(provider, body)).resolves.toStrictEqual({
+        message: '로그인되었습니다.',
+        accessToken,
+        refreshToken,
+      });
+    });
+
+    it('should be return success message when naver is not signup', async () => {
+      const provider: 'kakao' | 'naver' = 'naver';
+      const body: SocialLoginBodyDTO = {
+        code: 'test',
+        state: 'chalkak',
+      };
+      const nickname = 'test-nickname';
+      const providerUserId = 1;
+      mockUserRepository.findOne.mockResolvedValueOnce(null);
+      mockNaverUserRepository.findOne.mockResolvedValueOnce(null);
+      mockNaverUserRepository.findOne.mockResolvedValueOnce(users[0]);
+      mockSocialNaverService.getOauth2Token.mockResolvedValue({ access_token: 'accessToken' });
+      mockSocialNaverService.getUserInfo.mockResolvedValue({ id: providerUserId, nickname });
+      mockJwtService.sign.mockImplementation((payload: any, options: any) => {
+        return `token${options.secret}`;
+      });
+      const accessToken = `token${mockConfigService.get('JWT_ACCESS_TOKEN_SECRET')}`;
+      const refreshToken = `token${mockConfigService.get('JWT_REFRESH_TOKEN_SECRET')}`;
+
+      expect(service.oauthSignIn(provider, body)).resolves.toStrictEqual({
+        message: '로그인되었습니다.',
+        accessToken,
+        refreshToken,
+      });
+    });
+
+    it('should be return success message when kakao is not signup', async () => {
+      const provider: 'kakao' | 'naver' = 'kakao';
+      const body: SocialLoginBodyDTO = {
+        code: 'test',
+        state: 'chalkak',
+      };
+      const nickname = 'test-nickname';
+      const providerUserId = 1;
+      mockUserRepository.findOne.mockResolvedValueOnce(null);
+      mockKakaoUserRepository.findOne.mockResolvedValueOnce(null);
+      mockKakaoUserRepository.findOne.mockResolvedValueOnce(users[0]);
+      mockSocialKakaoService.getOauth2Token.mockResolvedValue({ access_token: 'accessToken' });
+      mockSocialKakaoService.getUserInfo.mockResolvedValue({ id: providerUserId, kakao_account: { profile: { nickname } } });
+      mockJwtService.sign.mockImplementation((payload: any, options: any) => {
+        return `token${options.secret}`;
+      });
+      const accessToken = `token${mockConfigService.get('JWT_ACCESS_TOKEN_SECRET')}`;
+      const refreshToken = `token${mockConfigService.get('JWT_REFRESH_TOKEN_SECRET')}`;
+
+      expect(service.oauthSignIn(provider, body)).resolves.toStrictEqual({
+        message: '로그인되었습니다.',
+        accessToken,
+        refreshToken,
+      });
+    });
+
+    
+    it('should be return success message when naver insert fail', async () => {
+      const provider: 'kakao' | 'naver' = 'naver';
+      const body: SocialLoginBodyDTO = {
+        code: 'test',
+        state: 'chalkak',
+      };
+      const nickname = 'test-nickname';
+      const providerUserId = 1;
+      mockUserRepository.findOne.mockResolvedValueOnce(null);
+      mockNaverUserRepository.findOne.mockResolvedValueOnce(null);
+      mockNaverUserRepository.insert.mockRejectedValue(new Error())
+      mockNaverUserRepository.findOne.mockResolvedValueOnce(users[0]);
+      mockSocialNaverService.getOauth2Token.mockResolvedValue({ access_token: 'accessToken' });
+      mockSocialNaverService.getUserInfo.mockResolvedValue({ id: providerUserId, nickname });
+      mockJwtService.sign.mockImplementation((payload: any, options: any) => {
+        return `token${options.secret}`;
+      });
+      const accessToken = `token${mockConfigService.get('JWT_ACCESS_TOKEN_SECRET')}`;
+      const refreshToken = `token${mockConfigService.get('JWT_REFRESH_TOKEN_SECRET')}`;
+
+      expect(service.oauthSignIn(provider, body)).rejects.toThrowError( new BadRequestException({
+        message: '가입에 실패했습니다.',
+      }));
+    });
+
+    it('should be return success message when kakao insert fail', async () => {
+      const provider: 'kakao' | 'naver' = 'kakao';
+      const body: SocialLoginBodyDTO = {
+        code: 'test',
+        state: 'chalkak',
+      };
+      const nickname = 'test-nickname';
+      const providerUserId = 1;
+      mockUserRepository.findOne.mockResolvedValueOnce(null);
+      mockKakaoUserRepository.findOne.mockResolvedValueOnce(null);
+      mockKakaoUserRepository.insert.mockRejectedValue(new Error())
+      mockKakaoUserRepository.findOne.mockResolvedValueOnce(users[0]);
+      mockSocialKakaoService.getOauth2Token.mockResolvedValue({ access_token: 'accessToken' });
+      mockSocialKakaoService.getUserInfo.mockResolvedValue({ id: providerUserId, kakao_account: { profile: { nickname } } });
+      mockJwtService.sign.mockImplementation((payload: any, options: any) => {
+        return `token${options.secret}`;
+      });
+      const accessToken = `token${mockConfigService.get('JWT_ACCESS_TOKEN_SECRET')}`;
+      const refreshToken = `token${mockConfigService.get('JWT_REFRESH_TOKEN_SECRET')}`;
+
+      expect(service.oauthSignIn(provider, body)).rejects.toThrowError( new BadRequestException({
+        message: '가입에 실패했습니다.',
+      }));
+    });
+
+    
+    it('should be return success message when user is block', async () => {
+      const provider: 'kakao' | 'naver' = 'kakao';
+      const body: SocialLoginBodyDTO = {
+        code: 'test',
+        state: 'chalkak',
+      };
+      const nickname = 'test-nickname';
+      const providerUserId = 1;
+      mockUserRepository.findOne.mockResolvedValueOnce(null);
+      mockKakaoUserRepository.findOne.mockResolvedValueOnce(null);
+      mockKakaoUserRepository.findOne.mockResolvedValueOnce(users[2]);
+      mockSocialKakaoService.getOauth2Token.mockResolvedValue({ access_token: 'accessToken' });
+      mockSocialKakaoService.getUserInfo.mockResolvedValue({ id: providerUserId, kakao_account: { profile: { nickname } } });
+      mockJwtService.sign.mockImplementation((payload: any, options: any) => {
+        return `token${options.secret}`;
+      });
+      const accessToken = `token${mockConfigService.get('JWT_ACCESS_TOKEN_SECRET')}`;
+      const refreshToken = `token${mockConfigService.get('JWT_REFRESH_TOKEN_SECRET')}`;
+
+      expect(service.oauthSignIn(provider, body)).rejects.toThrowError( new ForbiddenException({
+        message: '블락된 상태여서 로그인할 수 없습니다.',
+      }));
     });
   });
 

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -96,7 +96,7 @@ describe('AuthService', () => {
       providers: [AuthService],
     })
       .useMocker((token) => {
-        if (token === getRepositoryToken(LocalUser)) {
+        if (token === getRepositoryToken(User)) {
           return {
             insert: jest.fn(),
             findOne: jest.fn(),
@@ -163,7 +163,7 @@ describe('AuthService', () => {
     expect(service).toBeDefined();
   });
 
-  describe('signUp Method', () => {
+  describe('signUp Method(회원가입 메소드)', () => {
     it('should be defined', () => {
       expect(service.signUp).toBeDefined();
       expect(typeof service.signUp).toBe('function');
@@ -176,7 +176,28 @@ describe('AuthService', () => {
         password: 'testpassword',
       };
 
-      mockLocalUserRepository.insert.mockResolvedValue({ generatedMaps: [], identifiers: [], raw: false });
+      mockLocalUserRepository.insert.mockResolvedValue({
+        generatedMaps: [{ id: 3 }],
+        identifiers: [
+          {
+            id: 3,
+            isBlock: false,
+            createdAt: new Date('2023-03-06T15:01:25.962Z'),
+            updatedAt: new Date('2023-03-06T15:01:25.962Z'),
+            deletedAt: null,
+          },
+        ],
+        raw: {
+          fieldCount: 0,
+          affectedRows: 1,
+          insertId: 3,
+          serverStatus: 2,
+          warningCount: 0,
+          message: '',
+          protocol41: true,
+          changedRows: 0,
+        },
+      });
 
       expect(service.signUp(body)).resolves.toStrictEqual({
         message: '회원가입 되었습니다.',
@@ -184,13 +205,14 @@ describe('AuthService', () => {
     });
 
     it('should be return fail message when username error situation', async () => {
+      const { username } = users[0]
       const body: SignUpBodyDTO = {
-        username: '중복닉네임',
-        email: 'test@gmail.com',
-        password: 'testpassword',
+        username,
+        email: 'test5@gmail.com',
+        password: 'qwer1234',
       };
 
-      mockLocalUserRepository.findOne.mockResolvedValueOnce(users[0])
+      mockUserRepository.findOne.mockResolvedValueOnce(users[0]);
 
       expect(service.signUp(body)).rejects.toThrowError(
         new BadRequestException({
@@ -338,15 +360,15 @@ describe('AuthService', () => {
         code: 'test',
         state: 'chalkak',
       };
-      const nickname = 'test-nickname'
+      const nickname = 'test-nickname';
       const providerUserId = 1;
       mockUserRepository.findOne.mockResolvedValue(null);
       mockNaverUserRepository.findOne.mockResolvedValue({
         id: 1,
-        username: 'test'
+        username: 'test',
       } as NaverUser);
-      mockSocialNaverService.getOauth2Token.mockResolvedValue({access_token: 'accessToken'})
-      mockSocialNaverService.getUserInfo.mockResolvedValue({id: providerUserId, nickname})
+      mockSocialNaverService.getOauth2Token.mockResolvedValue({ access_token: 'accessToken' });
+      mockSocialNaverService.getUserInfo.mockResolvedValue({ id: providerUserId, nickname });
       mockJwtService.sign.mockImplementation((payload: any, options: any) => {
         return `token${options.secret}`;
       });
@@ -366,15 +388,15 @@ describe('AuthService', () => {
         code: 'test',
         state: 'chalkak',
       };
-      const nickname = 'test-nickname'
+      const nickname = 'test-nickname';
       const providerUserId = 1;
       mockUserRepository.findOne.mockResolvedValue(null);
       mockKakaoUserRepository.findOne.mockResolvedValue({
         id: 1,
-        username: 'test'
+        username: 'test',
       } as KakaoUser);
-      mockSocialKakaoService.getOauth2Token.mockResolvedValue({access_token: 'accessToken'})
-      mockSocialKakaoService.getUserInfo.mockResolvedValue({id: providerUserId, kakao_account: {profile: {nickname}}})
+      mockSocialKakaoService.getOauth2Token.mockResolvedValue({ access_token: 'accessToken' });
+      mockSocialKakaoService.getUserInfo.mockResolvedValue({ id: providerUserId, kakao_account: { profile: { nickname } } });
       mockJwtService.sign.mockImplementation((payload: any, options: any) => {
         return `token${options.secret}`;
       });
@@ -407,7 +429,7 @@ describe('AuthService', () => {
         email: 'test@gmail.com',
       } as LocalUser);
       mockJwtService.sign.mockReturnValueOnce(newAccessToken);
-      mockJwtService.verifyAsync.mockResolvedValue({})
+      mockJwtService.verifyAsync.mockResolvedValue({});
 
       expect(service.refreshAccessToken(accessToken, refreshToken)).resolves.toStrictEqual({
         accessToken: newAccessToken,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -62,11 +62,13 @@ export class AuthService {
 
   async signUp(body: SignUpBodyDTO) {
     const { username: _username, email, password } = body;
-    const user = !_.isNil(_username) ? await this.localUsersRepository.findOne({ where: { username: _username } }) : null;
-    if (!_.isNil(user)) {
-      throw new BadRequestException({
-        message: '해당 닉네임으로 이미 가입한 유저가 존재합니다.',
-      });
+    if (!_.isNil(_username)) {
+      const user = await this.usersRepository.findOne({ where: { username: _username } });
+      if (!_.isNil(user)) {
+        throw new BadRequestException({
+          message: '해당 닉네임으로 이미 가입한 유저가 존재합니다.',
+        });
+      }
     }
     const username = _username || `${email.split('@')[0]}#${Math.floor(Math.random() * 10000) + 1}`;
     const passwordHash = bcrypt.hashSync(password, 10);
@@ -82,14 +84,14 @@ export class AuthService {
 
   async signIn(body: SignInBodyDTO, response: any) {
     const { email, password } = body;
-    const user = await this.localUsersRepository.findOne({ where: { email }, select: ['id', 'email', 'username', 'password']});
+    const user = await this.localUsersRepository.findOne({ where: { email }, select: ['id', 'email', 'username', 'password'] });
     if (!user) {
       throw new NotFoundException({ message: '가입하지 않은 이메일입니다.' });
     }
     if (user.isBlock) {
       throw new ForbiddenException({
-        message: '블락된 상태여서 로그인할 수 없습니다.'
-      })
+        message: '블락된 상태여서 로그인할 수 없습니다.',
+      });
     }
     if (!bcrypt.compareSync(password, user.password)) {
       throw new UnauthorizedException({ message: '비밀번호가 일치하지 않습니다.' });
@@ -191,8 +193,8 @@ export class AuthService {
     }
     if (user!.isBlock) {
       throw new ForbiddenException({
-        message: '블락된 상태여서 로그인할 수 없습니다.'
-      })
+        message: '블락된 상태여서 로그인할 수 없습니다.',
+      });
     }
 
     const accessToken = this.generateUserAccessToken({

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -85,16 +85,13 @@ export class AuthService {
   async signIn(body: SignInBodyDTO, response: any) {
     const { email, password } = body;
     const user = await this.localUsersRepository.findOne({ where: { email }, select: ['id', 'email', 'username', 'password'] });
-    if (!user) {
-      throw new NotFoundException({ message: '가입하지 않은 이메일입니다.' });
+    if (!user || !bcrypt.compareSync(password, user.password)) {
+      throw new NotFoundException({ message: '이메일이나 비밀번호가 일치하지 않습니다.' });
     }
     if (user.isBlock) {
       throw new ForbiddenException({
         message: '블락된 상태여서 로그인할 수 없습니다.',
       });
-    }
-    if (!bcrypt.compareSync(password, user.password)) {
-      throw new UnauthorizedException({ message: '비밀번호가 일치하지 않습니다.' });
     }
     const accessToken = this.generateUserAccessToken(user);
     const refreshToken = this.generateUserRefreshToken();

--- a/src/collections/test/collections.controller.spec.ts
+++ b/src/collections/test/collections.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { CollectionsController } from '../collections.controller';
+import { CACHE_MANAGER } from '@nestjs/common';
 
 describe('CollectionsController', () => {
   let controller: CollectionsController;
@@ -7,7 +8,17 @@ describe('CollectionsController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [CollectionsController],
-    }).compile();
+    })
+      .useMocker((token) => {
+        if (token === CACHE_MANAGER) {
+          return {
+            get: jest.fn(),
+            set: jest.fn(),
+            del: jest.fn(),
+          };
+        }
+      })
+      .compile();
 
     controller = module.get<CollectionsController>(CollectionsController);
   });

--- a/src/meetups/test/meetups.controller.spec.ts
+++ b/src/meetups/test/meetups.controller.spec.ts
@@ -5,6 +5,7 @@ import { MeetupsService } from '../meetups.service';
 import { ModuleMocker, MockFunctionMetadata } from 'jest-mock';
 import { Meetup } from '../entities/meetup.entity';
 import { decodedAccessTokenDTO } from 'src/auth/dto/auth.dto';
+import { CACHE_MANAGER } from '@nestjs/common';
 
 const moduleMocker = new ModuleMocker(global);
 
@@ -16,6 +17,13 @@ describe('MeetupsController', () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [MeetupsController],
     }).useMocker((token) => {
+      if (token === CACHE_MANAGER) {
+          return {
+            get: jest.fn(),
+            set: jest.fn(),
+            del: jest.fn(),
+          };
+      }
       if (typeof token === 'function') {
         const mockMetadata = moduleMocker.getMetadata(token) as MockFunctionMetadata<any, any>;
         const Mock = moduleMocker.generateFromMetadata(mockMetadata);

--- a/src/photospot/photospot.controller.spec.ts
+++ b/src/photospot/photospot.controller.spec.ts
@@ -6,6 +6,7 @@ import { FileSystemStoredFile, NestjsFormDataModule } from 'nestjs-form-data';
 import { Photospot } from 'src/photospot/entities/photospot.entity';
 import { PhotospotController } from './photospot.controller';
 import { PhotospotService } from './photospot.service';
+import { CACHE_MANAGER } from '@nestjs/common';
 
 const moduleMocker = new ModuleMocker(global);
 
@@ -24,6 +25,13 @@ describe('PhotospotController', () => {
       controllers: [PhotospotController],
     })
       .useMocker((token) => {
+        if (token === CACHE_MANAGER) {
+          return {
+            get: jest.fn(),
+            set: jest.fn(),
+            del: jest.fn(),
+          };
+        }
         if (typeof token === 'function') {
           const mockMetadata = moduleMocker.getMetadata(token) as MockFunctionMetadata<any, any>;
           const Mock = moduleMocker.generateFromMetadata(mockMetadata);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택)
- [x] 기능 추가   
- [x] 기능 수정   
- [ ] 기능 삭제   
- [x] 버그 수정   
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 수정

### 변경 사항
- resolve #45 
    - 테스트코드 커버리지 높임. 에러 잡음(아직 간소화, 리팩토링은 못함)
    - 테스트코드를 수정하는 과정에서 인증의 일부 기능을 리팩토링
    - .then이나 .catch를 하면 undefined의 then이나 catch를 참고 못 한다는 에러가 자꾸 떠서, 그냥 try-catch로 감싸서 예외처리.
- 로그인할 때 이메일이 가입되어있지 않거나, 비밀번호가 틀리면 '이메일이나 비밀번호가 일치하지 않는다'로 예외를 통일. 
- #64 에서 Guard에서 CACHE_MANAGER 토큰을 주입하여 controller 테스트 코드들에서 에러 발생했으므로 테스트 코드들에 CACHE_MANGER 토큰 모킹.

### 테스트 결과
기능이 정상적으로 동작하나 어드민, 콜렉션 쪽 테스트 코드 에러 발생

### 추가사항(자유롭게)