### PR TITLE
feat: 로그아웃을 원할때에 401을 날린다고 가정했을 때 불필요한 401을 제거하거나 401로 변경. (로그인, 인증메일…

### DIFF
--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -144,7 +144,7 @@ export class AdminService {
   private async isMasterAdmin(id: number) {
     const admin = await this.adminRepository.findOne({ where: { id }, select: { account: true } });
     if (admin?.account === 'master') {
-      throw new UnauthorizedException('마스터 관리자 계정은 삭제할 수 없습니다.');
+      throw new BadRequestException('마스터 관리자 계정은 삭제할 수 없습니다.');
     }
   }
 

--- a/src/admin/strategies/jwt.admin.strategy.ts
+++ b/src/admin/strategies/jwt.admin.strategy.ts
@@ -14,7 +14,7 @@ export class JwtAdminStrategy extends PassportStrategy(Strategy, 'jwt-admin') {
         (request: Request) => {
           let data = request?.cookies['auth-cookie'];
           if (!data) {
-            return new BadRequestException();
+            return new UnauthorizedException();
           }
           return data.accessToken;
         },

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -663,7 +663,7 @@ describe('AuthService', () => {
       cache = {
         refreshToken: 1,
       };
-      mockLocalUserRepository.findOne.mockResolvedValue({
+      mockUserRepository.findOne.mockResolvedValue({
         id: 1,
         email: 'test@gmail.com',
       } as LocalUser);

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -233,7 +233,7 @@ export class AuthService {
         message: '사용 만료되었습니다.',
       });
     }
-    const user = await this.localUsersRepository.findOne({
+    const user = await this.usersRepository.findOne({
       where: {
         id: userId,
       },

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -222,7 +222,7 @@ export class AuthService {
       });
     } catch (err) {
       if (err.name === 'JsonWebTokenError') {
-        throw new BadRequestException({
+        throw new UnauthorizedException({
           message: '정상 발급된 액세스 토큰이 아닙니다.',
         });
       }
@@ -240,7 +240,7 @@ export class AuthService {
       select: ['id', 'email'],
     });
     if (_.isNil(user)) {
-      throw new NotFoundException({
+      throw new UnauthorizedException({
         message: '탈퇴한 유저입니다.',
       });
     }


### PR DESCRIPTION
… 발송은 401이 있어도 예외)

### PR 타입(하나 이상의 PR 타입을 선택)
- [ ] 기능 추가   
- [x] 기능 수정   
- [ ] 기능 삭제   
- [ ] 버그 수정   
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 수정

### 변경 사항
- master 계정을 삭제하려고 할때 401 던지던 것을 400으로 수정. (Forbidden도 어울릴듯은 함)
- 관리자 토큰을 담은 auth-cookie 쿠키가 없으면 401로 변경.
- 액세스 토큰 재발급시에 실패하면 401 던짐
- (추가) 소셜 로그인 유저로 로그인 했을 때에 재발급 조건 검증에서 user를 가져올 때 localUserRepository를 사용해서 소셜 로그인이 없는 것처럼 나와 실패함. userRepository 사용으로 변경.

### 테스트 결과
- 정상

### 추가사항
- 클라이언트에서 401을 받으면 토큰 재발급을 자동으로 하도록 만들경우를 위한 예방 pr
