### PR TITLE
feat: 인증 백엔드 마무리

### DIFF
--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -54,6 +54,7 @@ describe('AuthController', () => {
       const body: SignUpBodyDTO = {
         email: 'testman@gmail.com',
         password: 'qwer1234',
+        verifyToken: 123456,
       };
       const mockReturnValue = { message: '회원가입 되었습니다.' };
       service.signUp.mockResolvedValue(mockReturnValue);
@@ -72,6 +73,7 @@ describe('AuthController', () => {
       const body: SignUpBodyDTO = {
         email: 'testman@gmail.com',
         password: 'qwer1234',
+        verifyToken: 123456,
       };
       const mockReturnValue = { message: '회원가입 되었습니다.' };
       service.signUp.mockResolvedValue(mockReturnValue);
@@ -108,6 +110,11 @@ describe('AuthController', () => {
     it('should be return value returned by service same name method', async () => {
       const user = {
         id: 1,
+        username: 'testman',
+        email: 'test@gmail.com',
+        role: 'member',
+        iat: 1000,
+        exp: 1001,
       };
       
       const mockReturnValue = { message: '로그아웃 되었습니다.' };
@@ -164,6 +171,11 @@ describe('AuthController', () => {
       };
       const user = {
         id: 1,
+        username: 'testman',
+        email: 'test@gmail.com',
+        role: 'member',
+        iat: 1000,
+        exp: 1001,
       };
       const mockReturnValue = { message: '비밀번호가 변경되었습니다.' };
       service.changePassword.mockResolvedValue(mockReturnValue);

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -91,11 +91,11 @@ describe('AuthController', () => {
         email: 'testman@gmail.com',
         password: 'qwer1234',
       };
-      const response = {};
+      
       const mockReturnValue = { message: '로그인 되었습니다.', accessToken: 'accessToken', refreshToken: 'refreshToken' };
       service.signIn.mockResolvedValue(mockReturnValue);
 
-      expect(controller.signIn(body, response)).resolves.toBe(mockReturnValue);
+      expect(controller.signIn(body)).resolves.toBe(mockReturnValue);
     });
   });
 
@@ -109,11 +109,11 @@ describe('AuthController', () => {
       const user = {
         id: 1,
       };
-      const response = {};
+      
       const mockReturnValue = { message: '로그아웃 되었습니다.' };
       service.signOut.mockResolvedValue(mockReturnValue);
 
-      expect(controller.signOut(user, response)).resolves.toBe(mockReturnValue);
+      expect(controller.signOut(user)).resolves.toBe(mockReturnValue);
     });
   });
 

--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -52,6 +52,7 @@ describe('AuthController', () => {
 
     it('should be return value returned by service same name method', async () => {
       const body: SignUpBodyDTO = {
+        username: 'testman',
         email: 'testman@gmail.com',
         password: 'qwer1234',
         verifyToken: 123456,
@@ -71,6 +72,7 @@ describe('AuthController', () => {
 
     it('should be return value returned by service same name method', async () => {
       const body: SignUpBodyDTO = {
+        username: 'testman',
         email: 'testman@gmail.com',
         password: 'qwer1234',
         verifyToken: 123456,

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -28,15 +28,15 @@ export class AuthController {
 
   @Post('signin')
   @HttpCode(200)
-  async signIn(@Body() body: SignInBodyDTO, @Res({ passthrough: true }) response: any) {
-    return await this.authService.signIn(body, response);
+  async signIn(@Body() body: SignInBodyDTO) {
+    return await this.authService.signIn(body);
   }
 
   @Post('signout')
   @UserGuard
   @HttpCode(200)
-  async signOut(@InjectUser() user: any, @Res({ passthrough: true }) response: any) {
-    return await this.authService.signOut(user, response);
+  async signOut(@InjectUser() user: any) {
+    return await this.authService.signOut(user);
   }
 
   @Post('emailverification')

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -7,6 +7,7 @@ import {
   PutEmailVerificationBodyDTO,
   ChangePasswordBodyDTO,
   ProviderDTO,
+  decodedAccessTokenDTO,
 } from './dto/auth.dto';
 import { InjectUser, Token, UserGuard } from './auth.decorator';
 import { JwtRefreshGuard } from './guard/jwt-refresh/jwt-refresh.guard';
@@ -35,7 +36,7 @@ export class AuthController {
   @Post('signout')
   @UserGuard
   @HttpCode(200)
-  async signOut(@InjectUser() user: any) {
+  async signOut(@InjectUser() user: decodedAccessTokenDTO) {
     return await this.authService.signOut(user);
   }
 
@@ -51,7 +52,7 @@ export class AuthController {
 
   @Patch('')
   @UserGuard
-  async changePassword(@Body() body: ChangePasswordBodyDTO, @InjectUser() user: any) {
+  async changePassword(@Body() body: ChangePasswordBodyDTO, @InjectUser() user: decodedAccessTokenDTO) {
     return await this.authService.changePassword(body, user);
   }
 

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -187,6 +187,10 @@ describe('AuthService', () => {
         username: '테스트맨',
         email: 'testman@gmail.com',
         password: 'testpassword',
+        verifyToken: 123456,
+      };
+      cache = {
+        [body.email + '_verifyToken']: body.verifyToken,
       };
 
       mockLocalUserRepository.insert.mockResolvedValue({
@@ -223,6 +227,10 @@ describe('AuthService', () => {
         username,
         email: 'test5@gmail.com',
         password: 'qwer1234',
+        verifyToken: 123456,
+      };
+      cache = {
+        [body.email + '_verifyToken']: body.verifyToken,
       };
 
       mockUserRepository.findOne.mockResolvedValue(users[0]);
@@ -236,8 +244,13 @@ describe('AuthService', () => {
 
     it('should be return fail message when error situation', async () => {
       const body: SignUpBodyDTO = {
+        username: 'testman',
         email: 'test@gmail.com',
         password: 'testpassword',
+        verifyToken: 123456,
+      };
+      cache = {
+        [body.email + '_verifyToken']: body.verifyToken,
       };
       mockLocalUserRepository.insert.mockRejectedValue(new Error());
 
@@ -321,7 +334,9 @@ describe('AuthService', () => {
 
     it('should be return success message when success situation', async () => {
       const user = {
-        id: 1,
+        ...users[0],
+        iat: 1000,
+        exp: 1001
       };
 
       expect(service.signOut(user)).resolves.toStrictEqual({
@@ -412,7 +427,9 @@ describe('AuthService', () => {
         password: 'changePW',
       };
       const user = {
-        id: 1,
+        ...users[0],
+        iat: 1000,
+        exp: 1001
       };
       cache = {
         'test@gmail.com_verifyToken': 123456,
@@ -648,8 +665,10 @@ describe('AuthService', () => {
         refreshToken: 1,
       };
       mockUserRepository.findOne.mockResolvedValue({
-        id: 1,
+        ...users[0],
         email: 'test@gmail.com',
+        iat: 1000,
+        exp: 1001
       } as LocalUser);
       mockJwtService.sign.mockReturnValueOnce(newAccessToken);
       mockJwtService.verifyAsync.mockResolvedValue({});

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -260,9 +260,6 @@ describe('AuthService', () => {
         email: 'test@gmail.com',
         password: 'testpassword',
       };
-      const response: any = {
-        cookie: jest.fn(() => response),
-      };
       mockLocalUserRepository.findOne.mockResolvedValue(users[0]);
       mockJwtService.sign.mockImplementation((payload: any, options: any) => {
         return `token${options.secret}`;
@@ -270,7 +267,7 @@ describe('AuthService', () => {
       const accessToken = `token${mockConfigService.get('JWT_ACCESS_TOKEN_SECRET')}`;
       const refreshToken = `token${mockConfigService.get('JWT_REFRESH_TOKEN_SECRET')}`;
 
-      expect(service.signIn(body, response)).resolves.toStrictEqual({
+      expect(service.signIn(body)).resolves.toStrictEqual({
         message: '로그인 되었습니다.',
         accessToken,
         refreshToken,
@@ -282,12 +279,9 @@ describe('AuthService', () => {
         email: 'fake' + users[0].email,
         password: 'testpassword',
       };
-      const response: any = {
-        cookie: jest.fn(() => response),
-      };
       mockLocalUserRepository.findOne.mockResolvedValue(null);
 
-      expect(service.signIn(body, response)).rejects.toThrowError(
+      expect(service.signIn(body)).rejects.toThrowError(
         new NotFoundException({ message: '이메일이나 비밀번호가 일치하지 않습니다.' })
       );
     });
@@ -297,12 +291,9 @@ describe('AuthService', () => {
         email: users[0].email,
         password: 'faketestpassword',
       };
-      const response: any = {
-        cookie: jest.fn(() => response),
-      };
       mockLocalUserRepository.findOne.mockResolvedValue(users[0]);
 
-      expect(service.signIn(body, response)).rejects.toThrowError(
+      expect(service.signIn(body)).rejects.toThrowError(
         new NotFoundException({ message: '이메일이나 비밀번호가 일치하지 않습니다.' })
       );
     });
@@ -312,12 +303,9 @@ describe('AuthService', () => {
         email: users[2].email,
         password: 'testpassword',
       };
-      const response: any = {
-        cookie: jest.fn(() => response),
-      };
       mockLocalUserRepository.findOne.mockResolvedValue(users[2]);
 
-      expect(service.signIn(body, response)).rejects.toThrowError(
+      expect(service.signIn(body)).rejects.toThrowError(
         new ForbiddenException({
           message: '블락된 상태여서 로그인할 수 없습니다.',
         })
@@ -335,12 +323,8 @@ describe('AuthService', () => {
       const user = {
         id: 1,
       };
-      const response: any = {
-        cookie: jest.fn(() => response),
-        clearCookie: jest.fn(() => response),
-      };
 
-      expect(service.signOut(user, response)).resolves.toStrictEqual({
+      expect(service.signOut(user)).resolves.toStrictEqual({
         message: '로그아웃 되었습니다.',
       });
     });
@@ -663,7 +647,7 @@ describe('AuthService', () => {
       cache = {
         refreshToken: 1,
       };
-      mockLocalUserRepository.findOne.mockResolvedValue({
+      mockUserRepository.findOne.mockResolvedValue({
         id: 1,
         email: 'test@gmail.com',
       } as LocalUser);

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -90,7 +90,7 @@ export class AuthService {
     };
   }
 
-  async signIn(body: SignInBodyDTO, response: any) {
+  async signIn(body: SignInBodyDTO) {
     const { email, password } = body;
     const user = await this.localUsersRepository.findOne({ where: { email }, select: ['id', 'email', 'username', 'password'] });
     if (!user || !bcrypt.compareSync(password, user.password)) {
@@ -111,7 +111,7 @@ export class AuthService {
     };
   }
 
-  async signOut(user: any, response: any) {
+  async signOut(user: any) {
     await this.cacheManager.del(user.id);
     return {
       message: '로그아웃 되었습니다.',

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -233,7 +233,7 @@ export class AuthService {
         message: '사용 만료되었습니다.',
       });
     }
-    const user = await this.localUsersRepository.findOne({
+    const user = await this.usersRepository.findOne({
       where: {
         id: userId,
       },

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -68,7 +68,7 @@ export class AuthService {
   }
 
   async signUp(body: SignUpBodyDTO) {
-    const { username: _username, email, password, verifyToken } = body;
+    const { username, email, password, verifyToken } = body;
     const cachedVerifyToken = await this.cacheManager.get(email + '_verifyToken');
     if (!cachedVerifyToken) {
       throw new NotFoundException({
@@ -80,15 +80,12 @@ export class AuthService {
         message: '인증번호가 일치하지 않습니다.',
       });
     }
-    if (!_.isNil(_username)) {
-      const user = await this.usersRepository.findOne({ where: { username: _username } });
-      if (!_.isNil(user)) {
-        throw new BadRequestException({
-          message: '해당 닉네임으로 이미 가입한 유저가 존재합니다.',
-        });
-      }
+    const user = await this.usersRepository.findOne({ where: { username } });
+    if (!_.isNil(user)) {
+      throw new BadRequestException({
+        message: '해당 닉네임으로 이미 가입한 유저가 존재합니다.',
+      });
     }
-    const username = _username || `${email.split('@')[0]}#${Math.floor(Math.random() * 10000) + 1}`;
     const passwordHash = bcrypt.hashSync(password, 10);
     try {
       await this.localUsersRepository.insert({ username, email, password: passwordHash });

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -112,7 +112,7 @@ export class AuthService {
     }
     const accessToken = this.generateUserAccessToken(user);
     const refreshToken = this.generateUserRefreshToken();
-    this.cacheManager.set(refreshToken, user.id, { ttl: 1000 * 60 * 60 * 24 * 7 });
+    this.cacheManager.set(refreshToken, user.id, { ttl: 60 * 60 * 3 });
     return {
       message: '로그인 되었습니다.',
       accessToken,
@@ -131,7 +131,7 @@ export class AuthService {
     const { email } = body;
     const verifyToken = this.generateRandomNumber();
     await this.mailerAuthService.sendMailAuthMail(email, verifyToken);
-    this.cacheManager.set(email + '_verifyToken', verifyToken, { ttl: 1000 * 60 * 5 });
+    this.cacheManager.set(email + '_verifyToken', verifyToken, { ttl: 60 * 5 });
     return {
       message: '이메일 인증번호가 요청되었습니다.',
     };
@@ -215,7 +215,7 @@ export class AuthService {
       username: user!.username,
     });
     const refreshToken = this.generateUserRefreshToken();
-    this.cacheManager.set(refreshToken, user!.id, { ttl: 1000 * 60 * 60 * 24 * 7 });
+    this.cacheManager.set(refreshToken, user!.id, { ttl: 60 * 60 * 3 });
 
     return {
       accessToken,
@@ -255,6 +255,9 @@ export class AuthService {
     }
 
     const newAccessToken = this.generateUserAccessToken(user);
+    this.cacheManager.set(refreshToken, userId, {
+      ttl: 60 * 60 * 3
+    })
 
     return {
       accessToken: newAccessToken,

--- a/src/auth/dto/auth.dto.ts
+++ b/src/auth/dto/auth.dto.ts
@@ -41,13 +41,13 @@ export class VerifyTokenDTO {
   verifyToken: number;
 }
 
-export class SignInBodyDTO extends PickType(SignUpBodyDTO, ['email', 'password']) {}
+export class SignInBodyDTO extends PickType(SignUpBodyDTO, ['email', 'password'] as const) {}
 
-export class PostEmailVerificationBodyDTO extends PickType(SignUpBodyDTO, ['email']) {}
+export class PostEmailVerificationBodyDTO extends PickType(SignUpBodyDTO, ['email'] as const) {}
 
-export class PutEmailVerificationBodyDTO extends IntersectionType(PickType(SignUpBodyDTO, ['email']), VerifyTokenDTO) {}
+export class PutEmailVerificationBodyDTO extends IntersectionType(PickType(SignUpBodyDTO, ['email'] as const), VerifyTokenDTO) {}
 
-export class ChangePasswordBodyDTO extends PickType(SignUpBodyDTO, ['password']) {}
+export class ChangePasswordBodyDTO extends PickType(SignUpBodyDTO, ['password'] as const) {}
 
 export class ProviderDTO {
   @IsIn(['kakao', 'naver'], {

--- a/src/auth/dto/auth.dto.ts
+++ b/src/auth/dto/auth.dto.ts
@@ -31,9 +31,6 @@ export class SignUpBodyDTO {
     }
   )
   password: string;
-}
-
-export class VerifyTokenDTO {
   @Type(() => Number)
   @IsInt({
     message: '이메일 인증토큰은 정수여야합니다.',
@@ -45,7 +42,7 @@ export class SignInBodyDTO extends PickType(SignUpBodyDTO, ['email', 'password']
 
 export class PostEmailVerificationBodyDTO extends PickType(SignUpBodyDTO, ['email'] as const) {}
 
-export class PutEmailVerificationBodyDTO extends IntersectionType(PickType(SignUpBodyDTO, ['email'] as const), VerifyTokenDTO) {}
+export class PutEmailVerificationBodyDTO extends PickType(SignUpBodyDTO, ['email', 'verifyToken'] as const) {}
 
 export class ChangePasswordBodyDTO extends PickType(SignUpBodyDTO, ['password'] as const) {}
 

--- a/src/auth/dto/auth.dto.ts
+++ b/src/auth/dto/auth.dto.ts
@@ -1,16 +1,18 @@
 import { IntersectionType, PickType } from '@nestjs/mapped-types';
 import { Type } from 'class-transformer';
-import { IsEmail, IsInt, IsNotEmpty, IsOptional, IsNumber, IsString, IsStrongPassword, IsIn } from 'class-validator';
+import { IsEmail, IsInt, IsNotEmpty, IsOptional, IsNumber, IsString, IsStrongPassword, IsIn, MaxLength } from 'class-validator';
 
 export class SignUpBodyDTO {
-  @IsOptional()
   @IsNotEmpty({
     message: '유저명은 빈문자열이면 안 됩니다.'
   })
   @IsString({
     message: '유저명은 문자열이어야 합니다.'
   })
-  username?: string;
+  @MaxLength(16, {
+    message: '유저명은 16글자 이내여야합니다.'
+  })
+  username: string;
   @IsEmail(
     {},
     {

--- a/src/auth/guard/block-user/block-user.guard.ts
+++ b/src/auth/guard/block-user/block-user.guard.ts
@@ -29,7 +29,7 @@ export class BlockUserGuard implements CanActivate {
       });
     }
     await this.cacheManager.set<boolean>(`user-${userId}-block`, user.isBlock, {
-      ttl: 1000 * 60 * 5
+      ttl: 60 * 5
     })
     if (user.isBlock) {
       throw new ForbiddenException({


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택)
- [x] 기능 추가   
- [x] 기능 수정   
- [ ] 기능 삭제   
- [x] 버그 수정   
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 수정

### 변경 사항
- resolve #113
  - 로그인, 로그아웃의 불필요한 @Req와 흔적 제거
  - mapped-types를 사용에 as const 추가
  - 토큰 재발급 검증할 때 이메일 회원가입한 유저의 유저 정보만 보고 가입되어있는지 판단한 걸 수정.
  - 회원가입시 인증토큰을 함께 받아 보안 강화
  - 회원가입시 닉네임 설정 필수로 함.

### 테스트 결과
- 정상

### 추가사항
- 아래 코멘트의 프론트엔드 pr과 함께 테스트