### PR TITLE
feat: photospot의 photo random 5장 가져오는 api 추가

### DIFF
--- a/src/photospot/photospot.controller.ts
+++ b/src/photospot/photospot.controller.ts
@@ -53,7 +53,7 @@ export class PhotospotController {
     await this.photospotService.deletePhotospot(photospotId, userId);
   }
   
-  @Get('/photospot/random')
+  @Get('/photospots/random')
   async getRandomPhoto(): Promise<Photo[]> {
     return await this.photospotService.getRandomPhoto();
   }

--- a/src/photospot/photospot.controller.ts
+++ b/src/photospot/photospot.controller.ts
@@ -6,12 +6,13 @@ import { PhotospotService } from './photospot.service';
 import { Photospot } from './entities/photospot.entity';
 import { InjectUser, UserGuard } from '../auth/auth.decorator';
 import { FileVaildationPipe } from './pipes/FileValidation.pipe';
+import { Photo } from './entities/photo.entity';
 
-@Controller('/api/collections/:collectionId/photospots')
+@Controller('/api')
 export class PhotospotController {
   constructor(private readonly photospotService: PhotospotService) {}
 
-  @Post()
+  @Post('/collections/:collectionId/photospots')
   @UserGuard
   @UseInterceptors(FilesInterceptor('files'))
   async createPhotospot(
@@ -23,18 +24,18 @@ export class PhotospotController {
     await this.photospotService.createPhotospot(createPhtospotDto, files, userId, collectionId);
   }
 
-  @Get()
+  @Get('/collections/:collectionId/photospots')
   async getAllPhotospot(@Param('collectionId') collectionId: number): Promise<Photospot[]> {
     return this.photospotService.getAllPhotospot(collectionId);
   }
 
-  @Get('/:photospotId')
+  @Get('/collections/:collectionId/photospots/:photospotId')
   async getPhotospot(@Param('photospotId') photospotId: number): Promise<Photospot> {
     return this.photospotService.getPhotospot(photospotId);
   }
 
 
-  @Put('/:photospotId')
+  @Put('/collections/:collectionId/photospots/:photospotId')
   @UserGuard
   @UseInterceptors(FilesInterceptor('files'))
   async modifyPhotospot(
@@ -46,10 +47,14 @@ export class PhotospotController {
     await this.photospotService.modifyPhotospot(modifyPhotospot, files, photospotId, userId);
   }
 
-  @Delete('/:photospotId')
+  @Delete('/collections/:collectionId/photospots/:photospotId')
   @UserGuard
   async deletePhotospot(@Param('photospotId') photospotId: number, @InjectUser('id') userId: number) {
     await this.photospotService.deletePhotospot(photospotId, userId);
   }
   
+  @Get('/photospot/random')
+  async getRandomPhoto(): Promise<Photo[]> {
+    return await this.photospotService.getRandomPhoto();
+  }
 }

--- a/src/photospot/photospot.service.ts
+++ b/src/photospot/photospot.service.ts
@@ -135,4 +135,18 @@ export class PhotospotService {
     this.photospotRepository.softDelete(photospotId);
   }
 
+  async getRandomPhoto(): Promise<Photo[]> {
+    const photos = await this.photoRepository.createQueryBuilder('p')
+    .select([
+      'p.id',
+      'p.image'
+    ])
+    .orderBy('RAND()')
+    .limit(5)
+    .getMany();
+    if (_.isEmpty(photos)) {
+      throw new NotFoundException(`등록된 포토스팟이 없습니다.`);
+    }
+    return photos;
+  }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택)
- [x] 기능 추가   
- [ ] 기능 수정   
- [ ] 기능 삭제   
- [ ] 버그 수정   
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 수정

### 변경 사항
- resolve #136 
  - 프론트엔드 메인페이지용 등록된 포토스팟에서 랜덤 사진 5개 가져오는 api 추가

### 테스트 결과
- 추가된 controller, service 메서드에 대한 테스트 추후 추가 예정