### PR TITLE
feat: 비밀번호 재설정 기능

### DIFF
--- a/mailTemplates/resetPasswordMail.hbs
+++ b/mailTemplates/resetPasswordMail.hbs
@@ -1,0 +1,48 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <style>
+      /* CSS 스타일 */
+      body {
+        font-family: Arial, sans-serif;
+        font-size: 16px;
+        line-height: 1.5;
+        color: #333;
+        margin: 0;
+        padding: 0;
+      }
+      .container {
+        width: 80%;
+        margin: 0 auto;
+      }
+      h1 {
+        margin-top: 50px;
+        margin-bottom: 30px;
+        font-size: 24px;
+        font-weight: bold;
+        color: #333;
+      }
+      p {
+        margin-bottom: 20px;
+      }
+      a {
+        display: inline-block;
+        background-color: #007bff;
+        color: #fff;
+        padding: 10px 20px;
+        text-decoration: none;
+        border-radius: 4px;
+        margin-top: 30px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>[찰칵] 비밀번호 재설정</h1>
+      <p>안녕하세요, {{username}}님! 비밀번호를 재설정하려면 아래 버튼을 클릭하세요.</p>
+      <p><a href="{{resetLink}}">비밀번호 재설정하러가기</a></p>
+      <p>만약 이 이메일이 실수로 발송되었거나 여러분이 비밀번호를 변경 요청하지 않으셨다면, 이 이메일을 무시하셔도 됩니다.</p>
+    </div>
+  </body>
+</html>

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,15 +1,15 @@
 import { Body, Controller, Get, HttpCode, Param, Patch, Post, Put, UseGuards } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import {
-  PostEmailVerificationBodyDTO as PostSignupEmailVerificationBodyDTO,
+  SendEmailForSignupBodyDTO,
   SignUpBodyDTO,
-  PutEmailVerificationBodyDTO as PutSignupEmailVerificationBodyDTO,
+  VerifyEmailForSignupBodyDTO,
   ChangePasswordBodyDTO,
   ProviderDTO,
   decodedAccessTokenDTO,
-  PutChangePasswordVerificationBodyDTO,
-  PostResetPasswordEmailVerificationBodyDTO,
-  PutResetPasswordEmailVerificationBodyDTO,
+  VerifyEmailForChangePasswordBodyDTO,
+  SendEmailForResetPasswordBodyDTO,
+  ResetPasswordWithEmailVerificationBodyDTO,
 } from './dto/auth.dto';
 import { InjectUser, Token, UserGuard } from './auth.decorator';
 import { JwtRefreshGuard } from './guard/jwt-refresh/jwt-refresh.guard';
@@ -41,13 +41,13 @@ export class AuthController {
   }
 
   @Post('emailverification/signup')
-  async postSignupEmailVerification(@Body() body: PostSignupEmailVerificationBodyDTO) {
-    return await this.authService.postSignupEmailVerification(body);
+  async SendEmailForSignup(@Body() body: SendEmailForSignupBodyDTO) {
+    return await this.authService.SendEmailForSignup(body);
   }
 
   @Put('emailverification/signup')
-  async putSignupEmailVerification(@Body() body: PutSignupEmailVerificationBodyDTO) {
-    return await this.authService.putSignupEmailVerification(body);
+  async VerifyEmailForSignup(@Body() body: VerifyEmailForSignupBodyDTO) {
+    return await this.authService.VerifyEmailForSignup(body);
   }
 
   @Patch('')
@@ -64,8 +64,8 @@ export class AuthController {
 
   @Put('emailverification/password')
   @UserGuard
-  async putChangePasswordEmailVerification(@Body() body: PutChangePasswordVerificationBodyDTO, @InjectUser() user: decodedAccessTokenDTO) {
-    return await this.authService.putChangePasswordEmailVerification(body, user);
+  async verifyEmailForChangePassword(@Body() body: VerifyEmailForChangePasswordBodyDTO, @InjectUser() user: decodedAccessTokenDTO) {
+    return await this.authService.verifyEmailForChangePassword(body, user);
   }
 
   @Post('oauth/signin/:provider')
@@ -82,13 +82,13 @@ export class AuthController {
   }
 
   @Post('emailverification/reset-password')
-  async postResetPasswordEmailVerification(@Body() body: PostResetPasswordEmailVerificationBodyDTO) {
-    return await this.authService.postResetPasswordEmailVerification(body);
+  async sendEmailForResetPassword(@Body() body: SendEmailForResetPasswordBodyDTO) {
+    return await this.authService.sendEmailForResetPassword(body);
   }
 
   @Put('emailverification/reset-password')
-  async putResetPasswordEmailVerification(@Body() body: PutResetPasswordEmailVerificationBodyDTO) {
-    return await this.authService.putResetPasswordEmailVerification(body);
+  async resetPasswordWithEmailVerification(@Body() body: ResetPasswordWithEmailVerificationBodyDTO) {
+    return await this.authService.resetPasswordWithEmailVerification(body);
   }
 
   @Get('islogin')

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -8,6 +8,8 @@ import {
   ProviderDTO,
   decodedAccessTokenDTO,
   PutChangePasswordVerificationBodyDTO,
+  PostResetPasswordEmailVerificationBodyDTO,
+  PutResetPasswordEmailVerificationBodyDTO,
 } from './dto/auth.dto';
 import { InjectUser, Token, UserGuard } from './auth.decorator';
 import { JwtRefreshGuard } from './guard/jwt-refresh/jwt-refresh.guard';
@@ -77,6 +79,16 @@ export class AuthController {
   @UseGuards(JwtRefreshGuard)
   async renewAccessToken(@Token('accessToken') accessToken: string, @Token('refreshToken') refreshToken: string) {
     return await this.authService.renewAccessToken(accessToken, refreshToken);
+  }
+
+  @Post('emailverification/reset-password')
+  async postResetPasswordEmailVerification(@Body() body: PostResetPasswordEmailVerificationBodyDTO) {
+    return await this.authService.postResetPasswordEmailVerification(body);
+  }
+
+  @Put('emailverification/reset-password')
+  async putResetPasswordEmailVerification(@Body() body: PutResetPasswordEmailVerificationBodyDTO) {
+    return await this.authService.putResetPasswordEmailVerification(body);
   }
 
   @Get('islogin')

--- a/src/auth/auth.interface.ts
+++ b/src/auth/auth.interface.ts
@@ -1,1 +1,1 @@
-export type verifyTokenType = 'signup' | 'changePassword'
+export type verifyTokenType = 'signup' | 'changePassword' | 'resetPassword'

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -317,6 +317,11 @@ export class AuthService {
         message: '탈퇴한 유저입니다.',
       });
     }
+    if (this.authHashService.comparePassword(password, user.password)) {
+      throw new ConflictException({
+        message: '기존의 비밀번호로는 변경이 불가능합니다.'
+      })
+    }
     user.password = this.authHashService.hashPassword(password);
     await this.localUsersRepository.save(user);
     return {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -146,6 +146,12 @@ export class AuthService {
 
   async changePassword(body: ChangePasswordBodyDTO, user: decodedAccessTokenDTO) {
     const { password } = body;
+    const userInfo = await this.localUsersRepository.findOne({where: {id: user.id}, select: ['id', 'password']});
+    if (this.authHashService.comparePassword(password, userInfo!.password)) {
+      throw new ConflictException({
+        message: '기존의 비밀번호로는 변경이 불가능합니다.'
+      })
+    }
     const passwordHash = this.authHashService.hashPassword(password);
     await this.localUsersRepository.update(user.id, { password: passwordHash });
     return {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -10,15 +10,15 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { LocalUser, KakaoUser, NaverUser, User } from './entities/user.entity';
 import {
-  PostEmailVerificationBodyDTO,
+  SendEmailForSignupBodyDTO,
   SignUpBodyDTO,
-  PutEmailVerificationBodyDTO,
+  VerifyEmailForSignupBodyDTO,
   ChangePasswordBodyDTO,
   SocialLoginBodyDTO,
   decodedAccessTokenDTO,
-  PutChangePasswordVerificationBodyDTO,
-  PostResetPasswordEmailVerificationBodyDTO,
-  PutResetPasswordEmailVerificationBodyDTO,
+  VerifyEmailForChangePasswordBodyDTO,
+  SendEmailForResetPasswordBodyDTO,
+  ResetPasswordWithEmailVerificationBodyDTO,
 } from './dto/auth.dto';
 import { MailerAuthService } from 'src/mailer/services/mailer.auth.service';
 import _ from 'lodash';
@@ -110,7 +110,7 @@ export class AuthService {
     };
   }
 
-  async postSignupEmailVerification(body: PostEmailVerificationBodyDTO) {
+  async SendEmailForSignup(body: SendEmailForSignupBodyDTO) {
     const { email } = body;
     const user = await this.localUsersRepository.findOne({where: { email }})
     if (!_.isNil(user)) {
@@ -126,7 +126,7 @@ export class AuthService {
     };
   }
 
-  async putSignupEmailVerification(body: PutEmailVerificationBodyDTO) {
+  async VerifyEmailForSignup(body: VerifyEmailForSignupBodyDTO) {
     const { email, verifyToken } = body;
     
     const cachedVerifyToken = await this.authCacheService.getVerifyToken('signup', email);
@@ -175,7 +175,7 @@ export class AuthService {
     };
   }
 
-  async putChangePasswordEmailVerification(body: PutChangePasswordVerificationBodyDTO, user: decodedAccessTokenDTO) {
+  async verifyEmailForChangePassword(body: VerifyEmailForChangePasswordBodyDTO, user: decodedAccessTokenDTO) {
     const { verifyToken } = body;
     const { email } = user;
     if (_.isNil(email)) {
@@ -284,7 +284,7 @@ export class AuthService {
     };
   }
 
-  async postResetPasswordEmailVerification(body: PostResetPasswordEmailVerificationBodyDTO) {
+  async sendEmailForResetPassword(body: SendEmailForResetPasswordBodyDTO) {
     const { email, url } = body;
     const user = await this.localUsersRepository.findOne({where: { email }})
     if (_.isNil(user)) {
@@ -300,7 +300,7 @@ export class AuthService {
     };
   }
 
-  async putResetPasswordEmailVerification(body: PutResetPasswordEmailVerificationBodyDTO) {
+  async resetPasswordWithEmailVerification(body: ResetPasswordWithEmailVerificationBodyDTO) {
     const { email, verifyToken, password } = body;
     const cachedVerifyToken = await this.authCacheService.getVerifyToken('resetPassword', email);
     if (_.isNil(cachedVerifyToken)) {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -75,6 +75,7 @@ export class AuthService {
         message: '회원가입하는데 문제가 발생했습니다.',
       });
     }
+    this.authCacheService.deleteVerifyToken('signup', email);
     return {
       message: '회원가입 되었습니다.',
     };
@@ -193,6 +194,7 @@ export class AuthService {
         message: '인증번호가 일치하지 않습니다.',
       });
     }
+    this.authCacheService.deleteVerifyToken('changePassword', email);
     return {
       message: '패스워드변경 이메일 인증번호가 확인되었습니다.',
     };
@@ -324,6 +326,7 @@ export class AuthService {
     }
     user.password = this.authHashService.hashPassword(password);
     await this.localUsersRepository.save(user);
+    this.authCacheService.deleteVerifyToken('resetPassword', email);
     return {
       message: '비밀번호가 재설정되었습니다.'
     }

--- a/src/auth/dto/auth.dto.ts
+++ b/src/auth/dto/auth.dto.ts
@@ -53,22 +53,22 @@ export class SignInBodyDTO extends PickType(SignUpBodyDTO, ['email']) {
   password: string;
 }
 
-export class PostEmailVerificationBodyDTO extends PickType(SignUpBodyDTO, ['email']) {}
+export class SendEmailForSignupBodyDTO extends PickType(SignUpBodyDTO, ['email']) {}
 
-export class PutEmailVerificationBodyDTO extends PickType(SignUpBodyDTO, ['email', 'verifyToken']) {}
+export class VerifyEmailForSignupBodyDTO extends PickType(SignUpBodyDTO, ['email', 'verifyToken']) {}
 
-export class PutChangePasswordVerificationBodyDTO extends PickType(SignUpBodyDTO, ['verifyToken']) {}
+export class VerifyEmailForChangePasswordBodyDTO extends PickType(SignUpBodyDTO, ['verifyToken']) {}
 
 export class ChangePasswordBodyDTO extends PickType(SignUpBodyDTO, ['password']) {}
 
-export class PostResetPasswordEmailVerificationBodyDTO extends PickType(SignUpBodyDTO, ['email']) {
+export class SendEmailForResetPasswordBodyDTO extends PickType(SignUpBodyDTO, ['email']) {
   @IsString({
     message: 'url은 문자열이어야 합니다.'
   })
   url: string;
 }
 
-export class PutResetPasswordEmailVerificationBodyDTO extends PickType(SignUpBodyDTO, ['email', 'verifyToken', 'password']) {}
+export class ResetPasswordWithEmailVerificationBodyDTO extends PickType(SignUpBodyDTO, ['email', 'verifyToken', 'password']) {}
 
 export class ProviderDTO {
   @IsIn(['kakao', 'naver'], {

--- a/src/auth/dto/auth.dto.ts
+++ b/src/auth/dto/auth.dto.ts
@@ -1,6 +1,6 @@
 import { PickType } from '@nestjs/mapped-types';
 import { Type } from 'class-transformer';
-import { IsEmail, IsInt, IsNotEmpty, IsOptional, IsNumber, IsString, IsStrongPassword, IsIn, MaxLength, NotContains } from 'class-validator';
+import { IsEmail, IsInt, IsNotEmpty, IsOptional, IsNumber, IsString, IsStrongPassword, IsIn, MaxLength, NotContains, IsUrl } from 'class-validator';
 
 export class SignUpBodyDTO {
   @IsNotEmpty({
@@ -60,6 +60,15 @@ export class PutEmailVerificationBodyDTO extends PickType(SignUpBodyDTO, ['email
 export class PutChangePasswordVerificationBodyDTO extends PickType(SignUpBodyDTO, ['verifyToken']) {}
 
 export class ChangePasswordBodyDTO extends PickType(SignUpBodyDTO, ['password']) {}
+
+export class PostResetPasswordEmailVerificationBodyDTO extends PickType(SignUpBodyDTO, ['email']) {
+  @IsString({
+    message: 'url은 문자열이어야 합니다.'
+  })
+  url: string;
+}
+
+export class PutResetPasswordEmailVerificationBodyDTO extends PickType(SignUpBodyDTO, ['email', 'verifyToken', 'password']) {}
 
 export class ProviderDTO {
   @IsIn(['kakao', 'naver'], {

--- a/src/auth/services/auth.cache.service.ts
+++ b/src/auth/services/auth.cache.service.ts
@@ -11,8 +11,8 @@ export class AuthCacheService {
     return await this.cacheManager.get<number>(`${email}_${type}`);
   }
 
-  async storeVerifyToken(type: verifyTokenType, email: string, verifyToken: number) {
-    await this.cacheManager.set(`${email}_${type}`, verifyToken, { ttl: 60 * 5 });
+  async storeVerifyToken(type: verifyTokenType, email: string, verifyToken: number, ttl: number = 60 * 5) {
+    await this.cacheManager.set(`${email}_${type}`, verifyToken, { ttl });
   }
 
   async getUserIdByRefreshToken(refreshToken: string) {

--- a/src/auth/services/auth.cache.service.ts
+++ b/src/auth/services/auth.cache.service.ts
@@ -14,6 +14,10 @@ export class AuthCacheService {
   async storeVerifyToken(type: verifyTokenType, email: string, verifyToken: number, ttl: number = 60 * 5) {
     await this.cacheManager.set(`${email}_${type}`, verifyToken, { ttl });
   }
+  
+  async deleteVerifyToken(type: verifyTokenType, email: string) {
+    await this.cacheManager.del(`${email}_${type}`);
+  }
 
   async getUserIdByRefreshToken(refreshToken: string) {
     return await this.cacheManager.get<number>(refreshToken);

--- a/src/auth/test/auth.controller.spec.ts
+++ b/src/auth/test/auth.controller.spec.ts
@@ -3,7 +3,7 @@ import { AuthController } from '../auth.controller';
 import { AuthService } from '../auth.service';
 import { ModuleMocker, MockFunctionMetadata } from 'jest-mock';
 import { CACHE_MANAGER } from '@nestjs/common';
-import { ChangePasswordBodyDTO, decodedAccessTokenDTO, PostEmailVerificationBodyDTO, ProviderDTO, PutChangePasswordVerificationBodyDTO, PutEmailVerificationBodyDTO, SignInBodyDTO, SignUpBodyDTO, SocialLoginBodyDTO } from '../dto/auth.dto';
+import { ChangePasswordBodyDTO, decodedAccessTokenDTO, SendEmailForSignupBodyDTO, ProviderDTO, VerifyEmailForChangePasswordBodyDTO, VerifyEmailForSignupBodyDTO, SignInBodyDTO, SignUpBodyDTO, SocialLoginBodyDTO } from '../dto/auth.dto';
 import { LocalUser } from '../entities/user.entity';
 
 const moduleMocker = new ModuleMocker(global);
@@ -118,36 +118,36 @@ describe('AuthController', () => {
 
   describe('POST /api/auth/emailVerification (postEmailVerification)', () => {
     it('should be defined', () => {
-      expect(controller.postSignupEmailVerification).toBeDefined();
-      expect(typeof controller.postSignupEmailVerification).toBe('function');
+      expect(controller.SendEmailForSignup).toBeDefined();
+      expect(typeof controller.SendEmailForSignup).toBe('function');
     });
 
     it('should be return value returned by service same name method', async () => {
-      const body: PostEmailVerificationBodyDTO = {
+      const body: SendEmailForSignupBodyDTO = {
         email: 'testman@gmail.com',
       };
       const mockReturnValue = { message: '회원가입 이메일 인증번호가 요청되었습니다.' };
-      service.postSignupEmailVerification.mockResolvedValue(mockReturnValue);
+      service.SendEmailForSignup.mockResolvedValue(mockReturnValue);
 
-      expect(controller.postSignupEmailVerification(body)).resolves.toBe(mockReturnValue);
+      expect(controller.SendEmailForSignup(body)).resolves.toBe(mockReturnValue);
     });
   });
 
   describe('PUT /api/auth/emailVerification (putEmailVerification)', () => {
     it('should be defined', () => {
-      expect(controller.putSignupEmailVerification).toBeDefined();
-      expect(typeof controller.putSignupEmailVerification).toBe('function');
+      expect(controller.VerifyEmailForSignup).toBeDefined();
+      expect(typeof controller.VerifyEmailForSignup).toBe('function');
     });
 
     it('should be return value returned by service same name method', async () => {
-      const body: PutEmailVerificationBodyDTO = {
+      const body: VerifyEmailForSignupBodyDTO = {
         email: 'testman@gmail.com',
         verifyToken: 123456,
       };
       const mockReturnValue = { message: '회원가입 이메일 인증번호가 확인되었습니다.' };
-      service.putSignupEmailVerification.mockResolvedValue(mockReturnValue);
+      service.VerifyEmailForSignup.mockResolvedValue(mockReturnValue);
 
-      expect(controller.putSignupEmailVerification(body)).resolves.toBe(mockReturnValue);
+      expect(controller.VerifyEmailForSignup(body)).resolves.toBe(mockReturnValue);
     });
   });
 
@@ -193,14 +193,14 @@ describe('AuthController', () => {
     });
   });
 
-  describe('PUT /api/auth/emailVerification/password (putChangePasswordEmailVerification)', () => {
+  describe('PUT /api/auth/emailVerification/password (verifyEmailForChangePassword)', () => {
     it('should be defined', () => {
-      expect(controller.putChangePasswordEmailVerification).toBeDefined();
-      expect(typeof controller.putChangePasswordEmailVerification).toBe('function');
+      expect(controller.verifyEmailForChangePassword).toBeDefined();
+      expect(typeof controller.verifyEmailForChangePassword).toBe('function');
     });
 
     it('should be return value returned by service same name method', async () => {
-      const body: PutChangePasswordVerificationBodyDTO = {
+      const body: VerifyEmailForChangePasswordBodyDTO = {
         verifyToken: 123456,
       };
       const decodedPayload: decodedAccessTokenDTO = {
@@ -208,9 +208,9 @@ describe('AuthController', () => {
       } as decodedAccessTokenDTO;
 
       const mockReturnValue = { message: '패스워드변경 이메일 인증번호가 확인되었습니다.' };
-      service.putChangePasswordEmailVerification.mockResolvedValue(mockReturnValue);
+      service.verifyEmailForChangePassword.mockResolvedValue(mockReturnValue);
 
-      expect(controller.putChangePasswordEmailVerification(body, decodedPayload)).resolves.toBe(mockReturnValue);
+      expect(controller.verifyEmailForChangePassword(body, decodedPayload)).resolves.toBe(mockReturnValue);
     });
   });
 

--- a/src/auth/test/auth.service.spec.ts
+++ b/src/auth/test/auth.service.spec.ts
@@ -19,9 +19,9 @@ import { AuthService } from '../auth.service';
 import {
   ChangePasswordBodyDTO,
   decodedAccessTokenDTO,
-  PostEmailVerificationBodyDTO,
-  PutChangePasswordVerificationBodyDTO,
-  PutEmailVerificationBodyDTO,
+  SendEmailForSignupBodyDTO,
+  VerifyEmailForChangePasswordBodyDTO,
+  VerifyEmailForSignupBodyDTO,
   SignUpBodyDTO,
   SocialLoginBodyDTO,
 } from '../dto/auth.dto';
@@ -400,32 +400,32 @@ describe('AuthService', () => {
     });
   });
 
-  describe('postSignupEmailVerification', () => {
+  describe('SendEmailForSignup', () => {
     it('should be defined', () => {
-      expect(service.postSignupEmailVerification).toBeDefined();
-      expect(typeof service.postSignupEmailVerification).toBe('function');
+      expect(service.SendEmailForSignup).toBeDefined();
+      expect(typeof service.SendEmailForSignup).toBe('function');
     });
 
     it('정상 작동', () => {
-      const body: PostEmailVerificationBodyDTO = {
+      const body: SendEmailForSignupBodyDTO = {
         email: 'test@gmail.com',
       };
 
       mockLocalUsersRepository.findOne.mockResolvedValueOnce(null);
 
-      expect(service.postSignupEmailVerification(body)).resolves.toStrictEqual({
+      expect(service.SendEmailForSignup(body)).resolves.toStrictEqual({
         message: '회원가입 이메일 인증번호가 요청되었습니다.',
       });
     });
 
     it('이미 가입된 이메일', () => {
-      const body: PostEmailVerificationBodyDTO = {
+      const body: SendEmailForSignupBodyDTO = {
         email: 'test@gmail.com',
       };
 
       mockLocalUsersRepository.findOne.mockResolvedValueOnce(users[0] as LocalUser);
 
-      expect(service.postSignupEmailVerification(body)).rejects.toThrowError(
+      expect(service.SendEmailForSignup(body)).rejects.toThrowError(
         new ConflictException({
           message: '이미 가입된 이메일입니다.',
         })
@@ -433,34 +433,34 @@ describe('AuthService', () => {
     });
   });
 
-  describe('putSignupEmailVerification', () => {
+  describe('VerifyEmailForSignup', () => {
     it('should be defined', () => {
-      expect(service.putSignupEmailVerification).toBeDefined();
-      expect(typeof service.putSignupEmailVerification).toBe('function');
+      expect(service.VerifyEmailForSignup).toBeDefined();
+      expect(typeof service.VerifyEmailForSignup).toBe('function');
     });
 
     it('정상 작동', () => {
-      const body: PutEmailVerificationBodyDTO = {
+      const body: VerifyEmailForSignupBodyDTO = {
         email: 'test@gmail.com',
         verifyToken: 123456,
       };
 
       mockAuthCacheService.getVerifyToken.mockResolvedValueOnce(body.verifyToken);
 
-      expect(service.putSignupEmailVerification(body)).resolves.toStrictEqual({
+      expect(service.VerifyEmailForSignup(body)).resolves.toStrictEqual({
         message: '회원가입 이메일 인증번호가 확인되었습니다.',
       });
     });
 
     it('인증번호가 캐시되어있지 않음', () => {
-      const body: PutEmailVerificationBodyDTO = {
+      const body: VerifyEmailForSignupBodyDTO = {
         email: 'test@gmail.com',
         verifyToken: 123456,
       };
 
       mockAuthCacheService.getVerifyToken.mockResolvedValueOnce(undefined);
 
-      expect(service.putSignupEmailVerification(body)).rejects.toThrowError(
+      expect(service.VerifyEmailForSignup(body)).rejects.toThrowError(
         new NotFoundException({
           message: '인증번호를 요청하지 않았거나 만료되었습니다.',
         })
@@ -468,14 +468,14 @@ describe('AuthService', () => {
     });
 
     it('인증번호가 틀림', () => {
-      const body: PutEmailVerificationBodyDTO = {
+      const body: VerifyEmailForSignupBodyDTO = {
         email: 'test@gmail.com',
         verifyToken: 123456,
       };
 
       mockAuthCacheService.getVerifyToken.mockResolvedValueOnce(body.verifyToken + 10);
 
-      expect(service.putSignupEmailVerification(body)).rejects.toThrowError(
+      expect(service.VerifyEmailForSignup(body)).rejects.toThrowError(
         new UnauthorizedException({
           message: '인증번호가 일치하지 않습니다.',
         })
@@ -572,10 +572,10 @@ describe('AuthService', () => {
     });
   });
 
-  describe('putChangePasswordEmailVerification', () => {
+  describe('verifyEmailForChangePassword', () => {
     it('should be defined', () => {
-      expect(service.putChangePasswordEmailVerification).toBeDefined();
-      expect(typeof service.putChangePasswordEmailVerification).toBe('function');
+      expect(service.verifyEmailForChangePassword).toBeDefined();
+      expect(typeof service.verifyEmailForChangePassword).toBe('function');
     });
 
     it('정상 작동', () => {
@@ -586,13 +586,13 @@ describe('AuthService', () => {
         role: 'user',
       } as decodedAccessTokenDTO;
 
-      const body: PutChangePasswordVerificationBodyDTO = {
+      const body: VerifyEmailForChangePasswordBodyDTO = {
         verifyToken: 123456,
       };
 
       mockAuthCacheService.getVerifyToken.mockResolvedValueOnce(body.verifyToken);
 
-      expect(service.putChangePasswordEmailVerification(body, decodedPayload)).resolves.toStrictEqual({
+      expect(service.verifyEmailForChangePassword(body, decodedPayload)).resolves.toStrictEqual({
         message: '패스워드변경 이메일 인증번호가 확인되었습니다.',
       });
     });
@@ -604,11 +604,11 @@ describe('AuthService', () => {
         role: 'user',
       } as decodedAccessTokenDTO;
 
-      const body: PutChangePasswordVerificationBodyDTO = {
+      const body: VerifyEmailForChangePasswordBodyDTO = {
         verifyToken: 123456,
       };
 
-      expect(service.putChangePasswordEmailVerification(body, decodedPayload)).rejects.toThrowError(
+      expect(service.verifyEmailForChangePassword(body, decodedPayload)).rejects.toThrowError(
         new BadRequestException({
           message: '이메일, 패스워드로 가입한 유저가 아닙니다.',
         })
@@ -623,13 +623,13 @@ describe('AuthService', () => {
         role: 'user',
       } as decodedAccessTokenDTO;
 
-      const body: PutChangePasswordVerificationBodyDTO = {
+      const body: VerifyEmailForChangePasswordBodyDTO = {
         verifyToken: 123456,
       };
 
       mockAuthCacheService.getVerifyToken.mockResolvedValueOnce(undefined);
 
-      expect(service.putChangePasswordEmailVerification(body, decodedPayload)).rejects.toThrowError(
+      expect(service.verifyEmailForChangePassword(body, decodedPayload)).rejects.toThrowError(
         new NotFoundException({
           message: '인증번호를 요청하지 않았거나 만료되었습니다.',
         })
@@ -644,13 +644,13 @@ describe('AuthService', () => {
         role: 'user',
       } as decodedAccessTokenDTO;
 
-      const body: PutChangePasswordVerificationBodyDTO = {
+      const body: VerifyEmailForChangePasswordBodyDTO = {
         verifyToken: 123456,
       };
 
       mockAuthCacheService.getVerifyToken.mockResolvedValueOnce(body.verifyToken + 10);
 
-      expect(service.putChangePasswordEmailVerification(body, decodedPayload)).rejects.toThrowError(
+      expect(service.verifyEmailForChangePassword(body, decodedPayload)).rejects.toThrowError(
         new UnauthorizedException({
           message: '인증번호가 일치하지 않습니다.',
         })

--- a/src/mailer/services/mailer.auth.service.ts
+++ b/src/mailer/services/mailer.auth.service.ts
@@ -1,5 +1,6 @@
 import { MailerService } from '@nestjs-modules/mailer';
 import { Injectable } from '@nestjs/common';
+import { User } from 'src/auth/entities/user.entity';
 
 @Injectable()
 export class MailerAuthService {
@@ -23,6 +24,19 @@ export class MailerAuthService {
       template: 'changePasswordMailAuth',
       context: {
         verifyToken,
+      },
+    });
+  }
+
+  async sendResetPasswordAuthMail(url: string, email: string, username: string, verifyToken: number) {
+    const resetLink = `${url}/reset-password?verifyToken=${verifyToken}&email=${email}`
+    await this.mailerService.sendMail({
+      to: email,
+      subject: '[찰칵] 비밀번호 재설정을 위한 링크입니다.',
+      template: 'resetPasswordMail',
+      context: {
+        username,
+        resetLink,
       },
     });
   }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택)
- [x] 기능 추가   
- [x] 기능 수정   
- [ ] 기능 삭제   
- [ ] 버그 수정   
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 수정

### 변경 사항
- resolve #147 
  - 비밀번호 재설정 기능
  - 비밀번호 변경시에 같은 비밀번호는 예외 던지기
  - 인증번호로 한 번 인증하면 캐시가 삭제되도록 변경
  - 인증번호를 저장하는 시간을 설정 가능하도록 변경

### 테스트 결과
- 정상 (비밀번호 재설정 메소드는 아직 안함)

### 테스트 환경
- 프론트의 pr과 함께 테스트해야함.
- https://github.com/chalkak2023/Chalkak-Frontend/pull/114