### PR TITLE
refactor: chat - 채팅 목록 api 결과에 멤버들도 포함되게 변경

### DIFF
--- a/src/chat/test/chat.repository.spec.ts
+++ b/src/chat/test/chat.repository.spec.ts
@@ -50,22 +50,25 @@ describe('MeetupsRepsitory', () => {
 
   describe('getChatRooms Method', () => {
     it('Success', async () => {
-      const mockReturnValue = [new Meetup()];
+      const mockGetRawManyReturnValue = [{ meetupId: 1 }];
+      const mockGetManyReturnValue = [new Meetup()];
       jest.spyOn(mockMeetupRepository, 'createQueryBuilder').mockReturnValue({
         select: jest.fn().mockReturnThis(),
         leftJoin: jest.fn().mockReturnThis(),
         withDeleted: jest.fn().mockReturnThis(),
         where: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
+        andWhereInIds: jest.fn().mockReturnThis(),
         orderBy: jest.fn().mockReturnThis(),
-        getMany: jest.fn().mockResolvedValue(mockReturnValue),
+        getRawMany: jest.fn().mockResolvedValue(mockGetRawManyReturnValue),
+        getMany: jest.fn().mockResolvedValue(mockGetManyReturnValue),
       } as any);
 
       const userId = 1;
       const result = await repository.getChatRooms(userId);
 
-      expect(result).toBe(mockReturnValue);
-      expect(mockMeetupRepository.createQueryBuilder).toHaveBeenCalledTimes(1);
+      expect(result).toBe(mockGetManyReturnValue);
+      expect(mockMeetupRepository.createQueryBuilder).toHaveBeenCalledTimes(2);
       expect(mockMeetupRepository.createQueryBuilder).toHaveBeenCalledWith('m');
       expect(result).toBeInstanceOf(Array);
     });


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택)
- [ ] 기능 추가   
- [x] 기능 수정   
- [ ] 기능 삭제   
- [ ] 버그 수정   
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 수정

### 변경 사항
- 기존 메서드에 채팅방 멤버가 다 포함되게 변경 (기존에는 로그인된 유저만 보였음)

### 테스트 결과
- 추후 수정