### PR TITLE
chore: meetup 장소 글자 제한 8 글자 -> 20 글자로 변경

### DIFF
--- a/src/meetups/dto/create-meetup.dto.ts
+++ b/src/meetups/dto/create-meetup.dto.ts
@@ -18,7 +18,7 @@ export class CreateMeetupDTO {
   
   @IsNotEmpty({ message: '장소는 빈 문자열이 아니어야 합니다.' })
   @IsString({ message: '장소는 문자열이어야 합니다.' })
-  @MaxLength(8, { message: '장소는 8글자 이내여야합니다.' })
+  @MaxLength(20, { message: '장소는 20글자 이내여야합니다.' })
   readonly place: string;
 
   @Type(() => Date)


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택)
- [ ] 기능 추가   
- [ ] 기능 수정   
- [ ] 기능 삭제   
- [ ] 버그 수정   
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 수정

### 변경 사항
- 피드백 사항으로 자주 언급된 모임 장소명 글자 제한에 대해 8 글자 -> 20 글자로 변경

### 테스트 결과
- 정상