### PR TITLE
refactor: photospot 비동기 병렬처리, 데이터베이스 통신 리팩토링

### DIFF
--- a/src/photospot/photospot.service.spec.ts
+++ b/src/photospot/photospot.service.spec.ts
@@ -84,7 +84,7 @@ const mockPhoto = {
   user: new User(),
   photospot: new Photospot(),
   photoKeywords: [new PhotoKeyword()],
-}
+};
 
 describe('PhotospotService', () => {
   let service: PhotospotService;
@@ -133,12 +133,13 @@ describe('PhotospotService', () => {
           return {
             save: jest.fn(),
             findOne: jest.fn(),
+            find: jest.fn(),
           };
         }
         if (token === 'winston') {
           return {
             error: jest.fn(),
-          }
+          };
         }
         if (typeof token === 'function') {
           const mockMetadata = moduleMocker.getMetadata(token) as MockFunctionMetadata<any, any>;
@@ -328,12 +329,14 @@ describe('PhotospotService', () => {
   describe('service createImageKeyword', () => {
     it('createImageKeyword 성공', async () => {
       const photoKeywords = ['test1', 'test2', 'test3'];
-      const preKeyword = { id: 1, keyword: 'test1', photos: [mockPhoto] };
+      const keywordEntities = [
+        { id: 1, keyword: 'test1', photos: [mockPhoto] },
+        { id: 1, keyword: 'test2', photos: [mockPhoto] },
+      ];
       const insertKeyword = { id: 2, keyword: 'test4', photos: [mockPhoto] };
 
       jest.spyOn(mockGoogleService, 'imageLabeling').mockResolvedValue(photoKeywords);
-      jest.spyOn(mockPhotoKeywordRepositor, 'findOne').mockResolvedValue(preKeyword);
-      jest.spyOn(mockPhotoKeywordRepositor, 'findOne').mockResolvedValueOnce(null);
+      jest.spyOn(mockPhotoKeywordRepositor, 'find').mockResolvedValue(keywordEntities);
       jest.spyOn(mockPhotoKeywordRepositor, 'save').mockResolvedValue(insertKeyword);
       jest.spyOn(mockPhotoRepository, 'findOne').mockResolvedValue(mockPhoto);
 
@@ -342,7 +345,7 @@ describe('PhotospotService', () => {
       expect(mockGoogleService.imageLabeling).toHaveBeenCalledTimes(1);
       expect(mockGoogleService.imageLabeling).toHaveBeenCalledWith(imagePath);
       expect(await mockGoogleService.imageLabeling(imagePath)).toEqual(photoKeywords);
-      expect(mockPhotoKeywordRepositor.findOne).toHaveBeenCalledTimes(3);
+      expect(mockPhotoKeywordRepositor.find).toHaveBeenCalledTimes(1);
       expect(mockPhotoKeywordRepositor.save).toHaveBeenCalledTimes(1);
       expect(mockPhotoRepository.findOne).toHaveBeenCalledTimes(1);
       expect(mockPhotoRepository.save).toHaveBeenCalledTimes(1);
@@ -366,9 +369,9 @@ describe('PhotospotService', () => {
       const recommendPhoto = await service.getRecommendPhoto(photoId);
       expect(mockPhotoRepository.findOne).toHaveBeenCalledTimes(1);
       expect(mockPhotoRepository.createQueryBuilder).toHaveBeenCalledTimes(1);
-      expect(recommendPhoto).toEqual([mockPhoto])
-    })
-  })
+      expect(recommendPhoto).toEqual([mockPhoto]);
+    });
+  });
 
   describe('service getAllPhoto', () => {
     it('getAllPhoto 성공', async () => {
@@ -387,22 +390,22 @@ describe('PhotospotService', () => {
       expect(mockConfigService.get).toHaveBeenCalledTimes(1);
       expect(mockPhotoRepository.createQueryBuilder).toHaveBeenCalledTimes(1);
       expect(returnPhoto).toEqual([mockPhoto]);
-    })
-  })
+    });
+  });
 
   describe('service isSafePhoto', () => {
     it('isSafePhoto 사진 문제없음 성공', async () => {
-      const isSafe = true
+      const isSafe = true;
 
       service.getPhotospot = jest.fn(async () => mockPhotospots[0]);
       jest.spyOn(mockGoogleService, 'imageSafeGuard').mockResolvedValue(isSafe);
 
       await service.isSafePhoto(photospotId);
-      expect(service.getPhotospot).toHaveBeenCalledTimes(1)
-      expect(service.getPhotospot).toHaveBeenCalledWith(photospotId)
+      expect(service.getPhotospot).toHaveBeenCalledTimes(1);
+      expect(service.getPhotospot).toHaveBeenCalledWith(photospotId);
       expect(mockGoogleService.imageSafeGuard).toHaveBeenCalled();
       expect(mockPhotospotRepository.softRemove).not.toHaveBeenCalled();
       expect(mockPhotoRepository.delete).not.toHaveBeenCalled();
-    })
-  })
+    });
+  });
 });

--- a/src/photospot/photospot.service.ts
+++ b/src/photospot/photospot.service.ts
@@ -167,14 +167,15 @@ export class PhotospotService {
   async createImageKeyword(image: string, photoId: number): Promise<void> {
     try {
       const photoKeywords = await this.googleVisionService.imageLabeling(image);
+      const keywordEntities = await this.photoKeywordRepository.find({select : {keyword: true, id: true}});      
       const keyword = [];
       for (const photoKeyword of photoKeywords) {
         if (_.isUndefined(photoKeyword)) {
           continue;
         }
-
-        const preKeyword = await this.photoKeywordRepository.findOne({ where: { keyword: photoKeyword } });
-        if (_.isNil(preKeyword)) {
+        
+        const preKeyword = keywordEntities.find((keywordEntitie) => keywordEntitie.keyword === photoKeyword);
+        if (_.isUndefined(preKeyword)) {
           const insertKeyword = await this.photoKeywordRepository.save({ keyword: photoKeyword });
           keyword.push(insertKeyword);
         } else {
@@ -185,6 +186,7 @@ export class PhotospotService {
       if (_.isNil(photo)) {
         return;
       }
+      
       photo.photoKeywords = keyword;
       await this.photoRepository.save(photo);
     } catch (err) {

--- a/src/photospot/photospot.service.ts
+++ b/src/photospot/photospot.service.ts
@@ -143,8 +143,8 @@ export class PhotospotService {
       throw new NotAcceptableException('해당 포토스팟에 접근 할 수 없습니다');
     }
 
-    this.photospotRepository.softRemove(photospot);
-    this.photoRepository.delete({ photospotId: photospot.id });
+    await this.photospotRepository.softRemove(photospot);
+    await this.photoRepository.delete({ photospotId: photospot.id });
   }
 
   async getRandomPhoto(): Promise<Photo[]> {
@@ -228,10 +228,10 @@ export class PhotospotService {
         const isSafe = await this.googleVisionService.imageSafeGuard(photo.image);
         if (!isSafe) {
           if (photoCount === 1) {
-            this.photospotRepository.softRemove(photospot);
-            this.photoRepository.delete(photo.id);
+            await this.photospotRepository.softRemove(photospot);
+            await this.photoRepository.delete(photo.id);
           } else {
-            this.photoRepository.delete(photo.id);
+            await this.photoRepository.delete(photo.id);
           }
         }
       });

--- a/src/photospot/photospot.service.ts
+++ b/src/photospot/photospot.service.ts
@@ -143,8 +143,10 @@ export class PhotospotService {
       throw new NotAcceptableException('해당 포토스팟에 접근 할 수 없습니다');
     }
 
-    await this.photospotRepository.softRemove(photospot);
-    await this.photoRepository.delete({ photospotId: photospot.id });
+    await Promise.all([
+      this.photospotRepository.softRemove(photospot),
+      this.photoRepository.delete({ photospotId: photospot.id }),
+    ]);
   }
 
   async getRandomPhoto(): Promise<Photo[]> {
@@ -170,7 +172,7 @@ export class PhotospotService {
         if (_.isUndefined(photoKeyword)) {
           continue;
         }
-  
+
         const preKeyword = await this.photoKeywordRepository.findOne({ where: { keyword: photoKeyword } });
         if (_.isNil(preKeyword)) {
           const insertKeyword = await this.photoKeywordRepository.save({ keyword: photoKeyword });
@@ -223,13 +225,12 @@ export class PhotospotService {
     try {
       const photospot = await this.getPhotospot(photospotId);
       const photoCount = photospot.photos.length;
-  
+
       photospot.photos.forEach(async (photo) => {
         const isSafe = await this.googleVisionService.imageSafeGuard(photo.image);
         if (!isSafe) {
           if (photoCount === 1) {
-            await this.photospotRepository.softRemove(photospot);
-            await this.photoRepository.delete(photo.id);
+            await Promise.all([this.photospotRepository.softRemove(photospot), this.photoRepository.delete(photo.id)]);
           } else {
             await this.photoRepository.delete(photo.id);
           }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택)
- [ ] 기능 추가   
- [ ] 기능 수정   
- [ ] 기능 삭제   
- [ ] 버그 수정   
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [X] 기타 수정

### 변경 사항
- resolve #177 
  - isSafePhoto와 deletePhotospot 비동기 함수 병렬 처리 및 await 키워드 추가
  - createImageKeyword에서 preKeyword를 여러 번 반복해 데이터베이스와 통신하는 부분 개선
  - 테스트 코드 수정

### 테스트 결과
- 정상
